### PR TITLE
fix (camera): fix new centered camera

### DIFF
--- a/include/game/scenes/main_menu.h
+++ b/include/game/scenes/main_menu.h
@@ -17,6 +17,8 @@ using training_callback_t = std::function<void()>;
 
 class MainMenuScene {
 public:
+    static constexpr const char* SCENE_NAME = "MainMenuScene";
+    
     Scene& setup(
         create_callback_t create_callback,
         join_callback_t join_callback,

--- a/src/scenes/main_menu.cpp
+++ b/src/scenes/main_menu.cpp
@@ -38,11 +38,15 @@ Scene& MainMenuScene::setup(
     join_callback_t join_callback,
     training_callback_t training_callback
 ) {
-    const std::string main_menu_scene_tag = "MainMenuScene";
+    RenderingService& rendering_service = Engine::instance().services->get_service<RenderingService>().get();
+    int window_width = rendering_service.window().get_window_width();
+    int window_height = rendering_service.window().get_window_height();
 
     SceneService& scene_service = Engine::instance().services->get_service<SceneService>().get();
-    Scene& scene = scene_service.add_scene(main_menu_scene_tag);
-    scene.add_game_object<Camera>(scene, Color(), 1.0f, true);
+    Scene& scene = scene_service.add_scene(SCENE_NAME);
+    
+    auto& camera = scene.add_game_object<Camera>(scene, Color(), 1.0f, true);
+    camera.transform().position({window_width / 2.0f, window_height / 2.0f, 0.0f});
 
     GameObject& bg = scene.add_game_object("Background");
     bg.add_component<Sprite>("main_menu_bg", Color{255, 255, 255, 255}, 0, 0, 0, 0);

--- a/src/scenes/swamp.cpp
+++ b/src/scenes/swamp.cpp
@@ -1,7 +1,8 @@
 #include <game/scenes/swamp.h>
 
-#include <engine/physics/physics_service.h>
 #include <engine/core/engine.h>
+#include <engine/core/rendering/renderingService.h>
+#include <engine/physics/physics_service.h>
 #include <engine/public/scene_service.h>
 #include <engine/public/components/sprite.h>
 #include <engine/public/gameObject.h>
@@ -16,8 +17,14 @@ void load_players(Scene& scene, float start_x = 1000.0f, float start_y = 500.0f)
 
 Scene& SwampScene::setup() {
     const Engine& engine = Engine::instance();
+
+    RenderingService& rendering_service = Engine::instance().services->get_service<RenderingService>().get();
+    int window_width = rendering_service.window().get_window_width();
+    int window_height = rendering_service.window().get_window_height();
+
     Scene& scene = engine.services->get_service<SceneService>().get().add_scene(SCENE_NAME);
-    scene.add_game_object<Camera>(scene, Color(), 1.0f, true);
+    auto& camera = scene.add_game_object<Camera>(scene, Color(), 1.0f, true);
+    camera.transform().position({window_width / 2.0f, window_height / 2.0f, 0.0f});
     
     LevelLoader loader;
     loader.load_game_objects_from_json(

--- a/src/scenes/swamp_autum.cpp
+++ b/src/scenes/swamp_autum.cpp
@@ -3,13 +3,21 @@
 #include <game/scenes/level_loader.h>
 
 #include <engine/core/engine.h>
+#include <engine/core/rendering/renderingService.h>
 #include <engine/public/scene_service.h>
 #include <engine/public/gameObject.h>
 #include <engine/public/components/sprite.h>
 
 Scene& SwampAutumScene::setup() {
     Engine& engine = Engine::instance();
+
+    RenderingService& rendering_service = Engine::instance().services->get_service<RenderingService>().get();
+    int window_width = rendering_service.window().get_window_width();
+    int window_height = rendering_service.window().get_window_height();
+
     Scene& scene = engine.services->get_service<SceneService>().get().add_scene(SCENE_NAME);
+    auto& camera = scene.add_game_object<Camera>(scene, Color(), 1.0f, true);
+    camera.transform().position({window_width / 2.0f, window_height / 2.0f, 0.0f});
     
     LevelLoader loader;
     loader.load_game_objects_from_json(


### PR DESCRIPTION
This fixes the broken camera that comes from the new engine update. We can zoom and make it tracking, however its now centered to make it easer for following. So we need to calculate the offset of the screen to center it back.