### PR TITLE
feat (gizmo): add physics toggle

### DIFF
--- a/include/game/behaviors/physics_gizmo_toggle_behavior.h
+++ b/include/game/behaviors/physics_gizmo_toggle_behavior.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <engine/public/behavior.h>
+#include <engine/physics/physics_service.h>
+
+class PhysicsGizmoToggleBehavior : public Behavior {
+public:
+    PhysicsGizmoToggleBehavior() = default;
+    ~PhysicsGizmoToggleBehavior() override = default;    
+
+    void on_awake() override;
+    void on_update(float dt) override; 
+private:
+    std::optional<std::reference_wrapper<PhysicsService>> physics_service_;
+};

--- a/include/game/game.h
+++ b/include/game/game.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <engine/public/scene.h>
+
 /**
  * @brief The Game class manages the main game lifecycle.
  * 
@@ -10,5 +12,7 @@ public:
     static void initialize();
     static void run();
     static void shutdown();
+private:
+    static void bootstrap(Scene& first_scene);
 };
 

--- a/src/behaviors/physics_gizmo_toggle_behavior.cpp
+++ b/src/behaviors/physics_gizmo_toggle_behavior.cpp
@@ -1,0 +1,18 @@
+#include <game/behaviors/physics_gizmo_toggle_behavior.h>
+
+#include <engine/core/engine.h>
+#include <engine/input/input_manager.h>
+#include <engine/input/input_system.h>
+
+void PhysicsGizmoToggleBehavior::on_awake() {
+    physics_service_ = Engine::instance().services->get_service<PhysicsService>();
+}
+
+void PhysicsGizmoToggleBehavior::on_update(float dt) {
+    const IInputProvider &provider =
+        Engine::instance().services->get_service<InputManager>().get().provider();
+
+    if (provider.is_key_pressed(KeyCode::f2) && physics_service_.has_value()) {
+        physics_service_->get().debug_mode(!physics_service_->get().debug_mode());
+    }
+}

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -4,30 +4,16 @@
 #include <game/scenes/swamp.h>
 #include <game/scenes/swamp_autum.h>
 
+#include <engine/audio/audio_service.h>
 #include <engine/core/engine.h>
 #include <engine/core/rendering/assetService.h>
 #include <engine/core/rendering/renderingService.h>
-#include <engine/audio/audio_service.h>
 #include <engine/public/components/behaviorscript.h>
 #include <engine/public/scene_service.h>
 
 #include <game/pause_menu_ui.h>
 #include <game/behaviors/pause_play_behavior.h>
-
-namespace
-{
-    void strap_pause_menu(Scene& main_menu_scene)
-    {
-        auto ppmenu = std::make_unique<PauseMenuUI>(main_menu_scene);
-        ppmenu->mark_dont_destroy_on_load(true);
-
-        auto& ppc = main_menu_scene.add_game_object("Pause/Play controller");
-        ppc.add_component<BehaviorScript>(std::make_unique<PausePlayBehavior>(*ppmenu));
-        ppc.mark_dont_destroy_on_load(true);
-
-        main_menu_scene.add_game_object(std::move(ppmenu));
-    }
-}
+#include <game/behaviors/physics_gizmo_toggle_behavior.h>
 
 void Game::initialize() {
     const Engine& engine = Engine::instance();
@@ -283,11 +269,24 @@ void Game::run() {
         load_training_scene
     );
 
-    strap_pause_menu(main_menu_scene);
+    bootstrap(main_menu_scene);
     scene_service.load_scene(main_menu_scene.name());
 }
 
 void Game::shutdown() {
     Engine& engine = Engine::instance();
     engine.quit();
+}
+
+void Game::bootstrap(Scene& first_scene) {
+    auto& gizmo_toggle = first_scene.add_game_object("Gizmo Toggle");
+    gizmo_toggle.add_component<BehaviorScript>(std::make_unique<PhysicsGizmoToggleBehavior>());
+    gizmo_toggle.mark_dont_destroy_on_load(true);
+
+    auto& ppmenu = first_scene.add_game_object<PauseMenuUI>(first_scene);
+    ppmenu.mark_dont_destroy_on_load(true);
+
+    auto& ppc = first_scene.add_game_object("Pause/Play controller");
+    ppc.add_component<BehaviorScript>(std::make_unique<PausePlayBehavior>(ppmenu));
+    ppc.mark_dont_destroy_on_load(true);
 }


### PR DESCRIPTION
This PR adds the a toggle for the physics gizmo. I also refactor some of the main scene strapping to create a bit more order. Now there is a `bootstrap` private member which takes the first scene and allows to strap some onto it like the pause menu and toggle.