### PR TITLE
scale (weapon): knockback + hitbox height

### DIFF
--- a/include/game/behaviors/weapon_melee_behavior.h
+++ b/include/game/behaviors/weapon_melee_behavior.h
@@ -35,7 +35,6 @@ private:
     int range_;
     int swingspeed_;
     Point knockback_force_;
-    Point knockback_force_delta_;
 
     Point hitbox_offset_;
     Point sprite_offset_left_;
@@ -48,5 +47,4 @@ private:
     std::optional<std::reference_wrapper<Sprite>> sprite_component_;
     std::optional<std::reference_wrapper<BoxCollider2D>> hitbox_component_;
     std::optional<std::reference_wrapper<GameObject>> player_component_;
-
 };

--- a/src/behaviors/weapon_melee_behavior.cpp
+++ b/src/behaviors/weapon_melee_behavior.cpp
@@ -74,7 +74,7 @@ void WeaponMeleeBehavior::on_awake() {
                 }
 
                 auto& rb = other_gameobject.get_component<Rigidbody2D>()->get();
-                Point knockback = facing_right_ ? knockback_force_delta_ : Point{-knockback_force_delta_.x, -knockback_force_delta_.y};
+                Point knockback = facing_right_ ? knockback_force_ : Point{-knockback_force_.x, -knockback_force_.y};
                 rb.apply_impulse(Vector3{knockback.x, knockback.y, 0.0f});
             }
         });
@@ -86,9 +86,6 @@ void WeaponMeleeBehavior::on_update(float dt) {
 
     auto& rb = game_object().parent()->get().get_component<Rigidbody2D>()->get();
     auto& animator = sprite_gameobject_.get().get_component<Animator>()->get();
-
-    /// Update knockback delta
-    knockback_force_delta_ = {knockback_force_.x * dt * 1000, knockback_force_.y * dt * 1000};
 
     if (rb.velocity().x > 0) facing_right_ = true;
     else if (rb.velocity().x < 0) facing_right_ = false;
@@ -107,7 +104,6 @@ void WeaponMeleeBehavior::on_update(float dt) {
     if (provider.is_mouse_pressed(MouseButton::left) && !animator.is_playing()) {
         if (sprite_component_) {
             animator.set_animation(attack_animation_name_);
-
 
             Point animator_offset = facing_right_ ? animator_offset_right_ : animator_offset_left_;
             sprite_gameobject_.get()
@@ -132,6 +128,6 @@ void WeaponMeleeBehavior::on_update(float dt) {
         sprite_component_->get().texture(original_texture_name_);
         
         hitbox_component_->get().active(false);
-        hitbox_gameobject_.get().transform().local_position({0.0f, 0.0f, 0.0f});
+        hitbox_gameobject_.get().transform().local_position({0.0f, -100.0f, 0.0f});
     }
 }

--- a/src/prefabs/weapons/weapon_axe_player_object.cpp
+++ b/src/prefabs/weapons/weapon_axe_player_object.cpp
@@ -22,7 +22,7 @@ WeaponAxePlayerObject::WeaponAxePlayerObject(Scene& scene, GameObject& parent)
     auto& melee_weapon_hitbox = scene.add_game_object("Player_Melee_Weapon_Hitbox");
     melee_weapon_hitbox.parent(dynamic_cast<GameObject&>(*this));
     melee_weapon_hitbox.add_component<Rigidbody2D>(BodyType2D::Kinematic);
-    melee_weapon_hitbox.add_component<BoxCollider2D>(0.5f, 0.1f, 32.0f, 50.0f, Point{0.0f, 0.0f}, true, false);
+    melee_weapon_hitbox.add_component<BoxCollider2D>(0.5f, 0.1f, 32.0f, 60.0f, Point{0.0f, 0.0f}, true, false);
 
     /// Seperate game object for sprite
     auto& melee_weapon_sprite = scene.add_game_object("Player_Melee_Weapon_Sprite");
@@ -34,7 +34,7 @@ WeaponAxePlayerObject::WeaponAxePlayerObject(Scene& scene, GameObject& parent)
 
     const int damage = 40;
     const int range = 20;
-    const Point knockback_force = Point{300.0f, 100.0f};
+    const Point knockback_force = Point{200.0f, 100.0f};
 
     const Point hitbox_offset{60, 0};
     const Point sprite_offset_left{-5.0f, 0};

--- a/src/prefabs/weapons/weapon_bat_player_object.cpp
+++ b/src/prefabs/weapons/weapon_bat_player_object.cpp
@@ -22,7 +22,7 @@ WeaponBatPlayerObject::WeaponBatPlayerObject(Scene& scene, GameObject& parent)
     auto& melee_weapon_hitbox = scene.add_game_object("Player_Melee_Weapon_Hitbox");
     melee_weapon_hitbox.parent(dynamic_cast<GameObject&>(*this));
     melee_weapon_hitbox.add_component<Rigidbody2D>(BodyType2D::Kinematic);
-    melee_weapon_hitbox.add_component<BoxCollider2D>(0.5f, 0.1f, 32.0f, 50.0f, Point{0.0f, 0.0f}, true, false);
+    melee_weapon_hitbox.add_component<BoxCollider2D>(0.5f, 0.1f, 32.0f, 60.0f, Point{0.0f, 0.0f}, true, false);
 
     /// Seperate game object for sprite
     auto& melee_weapon_sprite = scene.add_game_object("Player_Melee_Weapon_Sprite");
@@ -34,7 +34,7 @@ WeaponBatPlayerObject::WeaponBatPlayerObject(Scene& scene, GameObject& parent)
 
     const int damage = 10;
     const int range = 20;
-    const Point knockback_force = Point{200.0f, 50.0f};
+    const Point knockback_force = Point{300.0f, 50.0f};
 
     const Point hitbox_offset{60, 0};
     const Point sprite_offset_left{30.0f, 0};

--- a/src/prefabs/weapons/weapon_sword_player_object.cpp
+++ b/src/prefabs/weapons/weapon_sword_player_object.cpp
@@ -22,7 +22,7 @@ WeaponSwordPlayerObject::WeaponSwordPlayerObject(Scene& scene, GameObject& paren
     auto& melee_weapon_hitbox = scene.add_game_object("Player_Melee_Weapon_Hitbox");
     melee_weapon_hitbox.parent(dynamic_cast<GameObject&>(*this));
     melee_weapon_hitbox.add_component<Rigidbody2D>(BodyType2D::Kinematic);
-    melee_weapon_hitbox.add_component<BoxCollider2D>(0.5f, 0.1f, 32.0f, 50.0f, Point{0.0f, 0.0f}, true, false);
+    melee_weapon_hitbox.add_component<BoxCollider2D>(0.5f, 0.1f, 32.0f, 60.0f, Point{0.0f, 0.0f}, true, false);
 
     /// Seperate game object for sprite
     auto& melee_weapon_sprite = scene.add_game_object("Player_Melee_Weapon_Sprite");
@@ -34,7 +34,7 @@ WeaponSwordPlayerObject::WeaponSwordPlayerObject(Scene& scene, GameObject& paren
 
     const int damage = 20;
     const int range = 25;
-    const Point knockback_force = Point{500.0f, 50.0f};
+    const Point knockback_force = Point{200.0f, 50.0f};
 
     const Point hitbox_offset{60, 0};
     const Point sprite_offset_left{15.0f, 0};


### PR DESCRIPTION
This PR addresses the delta time scaling of force. Impulses don't need this as they are instant force, so its scaled automatically. I did reduce the values a little and increased the hitbox height to match the player height.