### PR TITLE
fix (weapon): self collision

### DIFF
--- a/src/behaviors/weapon_melee_behavior.cpp
+++ b/src/behaviors/weapon_melee_behavior.cpp
@@ -62,7 +62,7 @@ void WeaponMeleeBehavior::on_awake() {
             auto other_parent_opt = other.parent();
             if (other_parent_opt.has_value()) {
                 auto& other_gameobject = other_parent_opt->get();
-                if (other_gameobject.tag() != "Player") return;
+                if (other_gameobject.tag() != "Player" && other_gameobject.id() != player_component_->get().id()) return;
 
                 auto behaviors = other_gameobject.get_components<BehaviorScript>();
                 for (auto& behavior_ref : behaviors) {


### PR DESCRIPTION
Apparently you could collide with yourself on weapon swings in certain situations. That should not be the case anymore. This is my fault as this check should have been there from the start.