### PR TITLE
refactor (player): movement + sliding fix

### DIFF
--- a/include/game/character/playerConstants.h
+++ b/include/game/character/playerConstants.h
@@ -5,4 +5,12 @@ namespace PlayerConstants {
     constexpr auto IDLE_ANIMATION = "capybara_default_idle_anim";
     constexpr auto JUMPING_ANIMATION = "capybara_default_jump_anim";
     constexpr auto CROUCHING_ANIMATION = "capybara_default_duck_anim";
+    constexpr auto DEATH_ANIMATION = "capybara_default_dead_anim";
+    constexpr auto HIT_ANIMATION = "capybara_default_hit_anim";
+
+    constexpr auto IDLE_TEXTURE = "capybara_default_idle";
+    constexpr auto CROUCHING_TEXTURE = "capybara_default_duck";
+    constexpr auto JUMPING_TEXTURE = "capybara_default_jump";
+    constexpr auto DEATH_TEXTURE = "capybara_default_dead";
+    constexpr auto HIT_TEXTURE = "capybara_default_hit";
 }

--- a/include/game/character/playerConstants.h
+++ b/include/game/character/playerConstants.h
@@ -11,6 +11,6 @@ namespace PlayerConstants {
     constexpr auto IDLE_TEXTURE = "capybara_default_idle";
     constexpr auto CROUCHING_TEXTURE = "capybara_default_duck";
     constexpr auto JUMPING_TEXTURE = "capybara_default_jump";
-    constexpr auto DEATH_TEXTURE = "capybara_default_dead";
+    constexpr auto DEATH_TEXTURE = "capybara_default_death";
     constexpr auto HIT_TEXTURE = "capybara_default_hit";
 }

--- a/include/game/character/player_movement_behavior.h
+++ b/include/game/character/player_movement_behavior.h
@@ -15,12 +15,17 @@ private:
   std::optional<std::reference_wrapper<Sprite>> sprite_opt_;
   std::optional<std::reference_wrapper<BoxCollider2D>> box_collider_opt_;
 
+  float latest_dt_;
+
   float horizontal_velocity_;
   float jumping_force_;
   float dropping_speed_;
   float double_jump_force_;
   float velocity_y_threshold_;
+  float knockback_decay_;
+  Vector3 knockback_velocity_;
 
+  bool is_grounded_;
   bool is_crouching_;
   bool is_jumping_;
   bool is_double_jumping_;
@@ -76,6 +81,8 @@ public:
   [[nodiscard]] float velocity_y_threshold() const;
   void velocity_y_threshold(const float threshold);
 
+  void apply_knockback(const Point& force);
+
   [[nodiscard]] bool is_crouching() const;
   [[nodiscard]] bool is_jumping() const;
   [[nodiscard]] bool is_double_jumping() const;
@@ -84,10 +91,10 @@ public:
   void set_local_player() noexcept; // If this player object belongs to you
   void set_controllable() noexcept; // If it should listen to user input
 
-  void handle_movement(std::vector<PlayerMovementTypes> movement);
+  void handle_movement(const std::vector<PlayerMovementTypes>& movement);
   void gather_input(std::vector<PlayerMovementTypes>& movement);
   void set_movement_flags(const std::vector<PlayerMovementTypes>& movement);
-  void apply_physics();
+  void apply_physics(const std::vector<PlayerMovementTypes>& movement);
   void update_animation();
   void send_movement_if_needed(const std::vector<PlayerMovementTypes>& movement);
 

--- a/include/game/character/player_movement_behavior.h
+++ b/include/game/character/player_movement_behavior.h
@@ -1,12 +1,14 @@
 #pragma once
-#include "engine/public/behavior.h"
-#include "engine/public/components/animator.h"
-#include "engine/public/components/colliders/box_collider_2d.h"
-#include "engine/public/components/rigidbody_2d.h"
-#include "engine/public/components/sprite.h"
-#include "engine/public/scene.h"
 
 #include <game/character/player_movement_types.h>
+
+#include <engine/public/behavior.h>
+#include <engine/public/components/animator.h>
+#include <engine/public/components/colliders/box_collider_2d.h>
+#include <engine/public/components/rigidbody_2d.h>
+#include <engine/public/components/sprite.h>
+#include <engine/public/scene.h>
+
 
 class PlayerMovementBehavior final : public Behavior {
 private:
@@ -21,9 +23,9 @@ private:
   float jumping_force_;
   float dropping_speed_;
   float double_jump_force_;
-  float velocity_y_threshold_;
+
   float knockback_decay_;
-  Vector3 knockback_velocity_;
+  Vector3 knockback_velocity_{0.f, 0.f, 0.f};
 
   bool is_grounded_;
   bool is_crouching_;
@@ -58,13 +60,35 @@ public:
                          Point default_crouching_offset);
   PlayerMovementBehavior(float horizontal_velocity, float jumping_force,
                          float dropping_speed, float double_jump_force,
-                         float velocity_y_threshold,
                          const float default_standing_height,
                          const float default_crouching_height,
                          Point default_standing_offset,
                          Point default_crouching_offset);
 
   ~PlayerMovementBehavior() override = default;
+
+  void on_start() override;
+  void on_update(float dt) override;
+
+  /// If this player object belongs to you
+  void set_local_player() noexcept; 
+  /// If it should listen to user input
+  void set_controllable() noexcept; 
+
+  void handle_movement(const std::vector<PlayerMovementTypes>& movement);
+  void gather_input(std::vector<PlayerMovementTypes>& movement);
+
+  void set_movement_flags(const std::vector<PlayerMovementTypes>& movement);
+  
+  void apply_physics();
+  void apply_animation();
+
+  void send_movement_if_needed(const std::vector<PlayerMovementTypes>& movement);
+
+  [[nodiscard]] bool is_crouching() const;
+  [[nodiscard]] bool is_jumping() const;
+  [[nodiscard]] bool is_double_jumping() const;
+  [[nodiscard]] bool is_walking() const;
 
   [[nodiscard]] float horizontal_velocity() const;
   void horizontal_velocity(const float speed);
@@ -78,26 +102,5 @@ public:
   [[nodiscard]] float double_jump_force() const;
   void double_jump_force(const float speed);
 
-  [[nodiscard]] float velocity_y_threshold() const;
-  void velocity_y_threshold(const float threshold);
-
   void apply_knockback(const Point& force);
-
-  [[nodiscard]] bool is_crouching() const;
-  [[nodiscard]] bool is_jumping() const;
-  [[nodiscard]] bool is_double_jumping() const;
-  [[nodiscard]] bool is_walking() const;
-
-  void set_local_player() noexcept; // If this player object belongs to you
-  void set_controllable() noexcept; // If it should listen to user input
-
-  void handle_movement(const std::vector<PlayerMovementTypes>& movement);
-  void gather_input(std::vector<PlayerMovementTypes>& movement);
-  void set_movement_flags(const std::vector<PlayerMovementTypes>& movement);
-  void apply_physics(const std::vector<PlayerMovementTypes>& movement);
-  void update_animation();
-  void send_movement_if_needed(const std::vector<PlayerMovementTypes>& movement);
-
-  void on_start() override;
-  void on_update(float dt) override;
 };

--- a/include/game/character/player_movement_types.h
+++ b/include/game/character/player_movement_types.h
@@ -1,3 +1,7 @@
+#pragma once
+
+#include <cstdint>
+
 enum class PlayerMovementTypes : uint8_t {
     MOVE_LEFT,
     MOVE_RIGHT,

--- a/src/behaviors/weapon_melee_behavior.cpp
+++ b/src/behaviors/weapon_melee_behavior.cpp
@@ -1,6 +1,8 @@
 #include <game/behaviors/weapon_melee_behavior.h>
 
 #include <game/character/player_controller.h>
+#include <game/character/player_movement_behavior.h>
+
 #include <engine/core/engine.h>
 #include <engine/input/input_system.h>
 #include <engine/input/input_manager.h>
@@ -69,15 +71,16 @@ void WeaponMeleeBehavior::on_awake() {
                 auto behaviors = other_gameobject.get_components<BehaviorScript>();
                 for (auto& behavior_ref : behaviors) {
                     auto& behavior = behavior_ref.get().behavior();
-
+                    
                     if (auto ctrl = dynamic_cast<PlayerController*>(&behavior); ctrl != nullptr) {
                         ctrl->damage(damage_);
                     }
+                    
+                    if (auto movement = dynamic_cast<PlayerMovementBehavior*>(&behavior); movement != nullptr) {
+                        Point knockback = facing_right_ ? knockback_force_ : Point{-knockback_force_.x, knockback_force_.y};
+                        movement->apply_knockback(knockback);
+                    }
                 }
-
-                auto& rb = other_gameobject.get_component<Rigidbody2D>()->get();
-                Point knockback = facing_right_ ? knockback_force_ : Point{-knockback_force_.x, -knockback_force_.y};
-                rb.apply_impulse(Vector3{knockback.x, knockback.y, 0.0f});
             }
         });
 }

--- a/src/character/player_movement_behavior.cpp
+++ b/src/character/player_movement_behavior.cpp
@@ -52,6 +52,7 @@ void PlayerMovementBehavior::on_start() {
   sprite_opt_       = get_component<Sprite>();
   box_collider_opt_ = get_component<BoxCollider2D>();
 
+  /// TO BE REMOVED AFTER ENGINE PATCH
   rigidbody_opt_->get().gravity_scale(3.0f);
 
   if (!player_has_required_components()) {

--- a/src/character/player_movement_behavior.cpp
+++ b/src/character/player_movement_behavior.cpp
@@ -52,9 +52,6 @@ void PlayerMovementBehavior::on_start() {
   sprite_opt_       = get_component<Sprite>();
   box_collider_opt_ = get_component<BoxCollider2D>();
 
-  /// TO BE REMOVED AFTER ENGINE PATCH
-  rigidbody_opt_->get().gravity_scale(3.0f);
-
   if (!player_has_required_components()) {
     throw std::runtime_error("PlayerMovementBehavior missing components");
   }

--- a/src/character/player_movement_behavior.cpp
+++ b/src/character/player_movement_behavior.cpp
@@ -14,7 +14,7 @@ PlayerMovementBehavior::PlayerMovementBehavior()
 PlayerMovementBehavior::PlayerMovementBehavior(
     const float default_standing_height, const float default_crouching_height,
     const Point default_standing_offset, const Point default_crouching_offset)
-    : PlayerMovementBehavior(20.0f, 8.0f, 1.5f, 6.0f, 18.0f,
+    : PlayerMovementBehavior(30.0f, 8.0f, 1.5f, 6.0f, 18.0f,
                              default_standing_height, default_crouching_height,
                              default_standing_offset,
                              default_crouching_offset) {}
@@ -32,11 +32,11 @@ PlayerMovementBehavior::PlayerMovementBehavior(
       // Configurable params for movement physics
       horizontal_velocity_(horizontal_velocity), jumping_force_(jumping_force),
       dropping_speed_(dropping_speed), double_jump_force_(double_jump_force),
-      velocity_y_threshold_(velocity_y_threshold),
+      velocity_y_threshold_(velocity_y_threshold), knockback_decay_(7.0f),
 
       // State flags
-      is_crouching_(false), is_jumping_(false), is_double_jumping_(false),
-      is_walking_(false),
+      is_grounded_(false), is_crouching_(false), is_jumping_(false),
+      is_double_jumping_(false), is_walking_(false),
 
       // Default collider heights
       default_standing_height_(default_standing_height),
@@ -47,43 +47,34 @@ PlayerMovementBehavior::PlayerMovementBehavior(
       default_crouching_offset_(default_crouching_offset) {}
 
 void PlayerMovementBehavior::on_start() {
-  rigidbody_opt_ = this->get_component<Rigidbody2D>();
-  animator_opt_ = this->get_component<Animator>();
-  sprite_opt_ = this->get_component<Sprite>();
-  box_collider_opt_ = this->get_component<BoxCollider2D>();
+  rigidbody_opt_    = get_component<Rigidbody2D>();
+  animator_opt_     = get_component<Animator>();
+  sprite_opt_       = get_component<Sprite>();
+  box_collider_opt_ = get_component<BoxCollider2D>();
 
   if (!player_has_required_components()) {
-    throw std::runtime_error(
-        "player_has_required_components() returned false in "
-        "PlayerMovementBehavior::on_start");
+    throw std::runtime_error("PlayerMovementBehavior missing components");
   }
 
-  box_collider_opt_.value().get().add_on_collision_enter(
-      [&](Collider2D &self, Collider2D &other) {
-        const auto parent_opt = self.parent();
-        const auto other_parent_opt = other.parent();
-        if (!parent_opt.has_value() || !other_parent_opt.has_value())
-          return;
+  auto& collider = box_collider_opt_->get();
 
-        const Transform &self_transform = parent_opt->get().transform();
-        const Transform &other_transform = other_parent_opt->get().transform();
+  collider.add_on_collision_enter(
+    [&](Collider2D& self, Collider2D& other) {
+      if (other.parent()->get().tag() != "Ground")
+        return;
 
-        // Are we grounded?
-        if (self_transform.position().y > other_transform.position().y) {
-          return;
-        }
+      is_grounded_ = true;
+      is_jumping_ = false;
+      is_double_jumping_ = false;
 
-        // If we are both walking and jumping at the same time, resume walking
-        if (is_walking_ && is_jumping_) {
-          animator_opt_->get().play("capybara_default_walk_anim", true);
-        }
+      self.friction(0.6f);
+    });
 
-        is_jumping_ = false;
-        is_double_jumping_ = false;
-
-        Vector3 velocity = rigidbody_opt_->get().velocity();
-        rigidbody_opt_->get().velocity({velocity.x, 0.0f, velocity.z});
-      });
+  collider.add_on_collision_exit(
+    [&](Collider2D& self, Collider2D& other) {
+      if (other.parent()->get().tag() == "Ground")
+        is_grounded_ = false;
+    });
 }
 
 bool PlayerMovementBehavior::player_has_required_components() const {
@@ -99,123 +90,163 @@ void PlayerMovementBehavior::set_controllable() noexcept {
   is_controllable_ = true;
 }
 
-void PlayerMovementBehavior::on_update(float dt)
-{
-  if (is_controllable_) {
-    std::vector<PlayerMovementTypes> movement;
+void PlayerMovementBehavior::on_update(float dt) {
+  latest_dt_ = dt;
 
-    gather_input(movement);
-    handle_movement(movement);
-
-    if (is_local_player_)
-      send_movement_if_needed(movement);
-  } else {
-    apply_physics();
+  if (!is_controllable_) {
+    apply_physics({});
+    update_animation();
+    return;
   }
+
+  std::vector<PlayerMovementTypes> movement;
+  gather_input(movement);
+
+  handle_movement(movement);
+
+  if (is_local_player_)
+    send_movement_if_needed(movement);
 }
 
-void PlayerMovementBehavior::handle_movement(std::vector<PlayerMovementTypes> movement) {
+
+void PlayerMovementBehavior::handle_movement(
+  const std::vector<PlayerMovementTypes>& movement
+) {
   set_movement_flags(movement);
-  apply_physics();
+  apply_physics(movement);
   update_animation();
 }
 
-void PlayerMovementBehavior::gather_input(std::vector<PlayerMovementTypes>& movement) {
-  const IInputProvider& input_provider =
-      Engine::instance().services->get_service<InputManager>().get().provider();
 
-    if (input_provider.is_key_held(KeyCode::s)) movement.push_back(PlayerMovementTypes::CROUCH);
-    if (input_provider.is_key_held(KeyCode::space)
-      || input_provider.is_key_held(KeyCode::w)) movement.push_back(PlayerMovementTypes::JUMP);
-    if (input_provider.is_key_held(KeyCode::a)) movement.push_back(PlayerMovementTypes::MOVE_LEFT);
-    if (input_provider.is_key_held(KeyCode::d)) movement.push_back(PlayerMovementTypes::MOVE_RIGHT);
+void PlayerMovementBehavior::gather_input(
+  std::vector<PlayerMovementTypes>& movement
+) {
+  const auto& input =
+    Engine::instance().services
+      ->get_service<InputManager>().get().provider();
+
+  if (input.is_key_held(KeyCode::a))
+    movement.push_back(PlayerMovementTypes::MOVE_LEFT);
+
+  if (input.is_key_held(KeyCode::d))
+    movement.push_back(PlayerMovementTypes::MOVE_RIGHT);
+
+  if (input.is_key_held(KeyCode::s))
+    movement.push_back(PlayerMovementTypes::CROUCH);
+
+  if (input.is_key_pressed(KeyCode::space) ||
+      input.is_key_pressed(KeyCode::w))
+    movement.push_back(PlayerMovementTypes::JUMP);
 }
 
-void PlayerMovementBehavior::set_movement_flags(const std::vector<PlayerMovementTypes>& movement) {
-  crouch_ = std::find(movement.begin(), movement.end(), PlayerMovementTypes::CROUCH) != movement.end();
-  jump_ = std::find(movement.begin(), movement.end(), PlayerMovementTypes::JUMP) != movement.end();
-  move_left_ = std::find(movement.begin(), movement.end(), PlayerMovementTypes::MOVE_LEFT) != movement.end();
-  move_right_ = std::find(movement.begin(), movement.end(), PlayerMovementTypes::MOVE_RIGHT) != movement.end();
+
+void PlayerMovementBehavior::set_movement_flags(
+  const std::vector<PlayerMovementTypes>& movement
+) {
+  auto has = [&](const std::vector<PlayerMovementTypes>& vec,
+                 PlayerMovementTypes type) {
+    return std::find(vec.begin(), vec.end(), type) != vec.end();
+  };
+
+  move_left_  = has(movement, PlayerMovementTypes::MOVE_LEFT);
+  move_right_ = has(movement, PlayerMovementTypes::MOVE_RIGHT);
+  crouch_     = has(movement, PlayerMovementTypes::CROUCH);
+  jump_       = has(movement, PlayerMovementTypes::JUMP);
 }
 
-void PlayerMovementBehavior::apply_physics()
-{
+void PlayerMovementBehavior::apply_physics(
+  const std::vector<PlayerMovementTypes>& movement
+) {
   if (!player_has_required_components())
     return;
 
-  auto& rigidbody = rigidbody_opt_->get();
-  auto& box_collider = box_collider_opt_->get();
+  auto& rb  = rigidbody_opt_->get();
+  auto& col = box_collider_opt_->get();
 
-  // crouch collider logic
-  if (crouch_ && !is_crouching_) {
-    box_collider.offset(default_crouching_offset_);
-    box_collider.height(default_crouching_height_);
+  Vector3 velocity = rb.velocity();
+  Vector3 force = {};
+
+  float horizontal = 0.0f;
+  if (!is_crouching_) {
+    if (move_left_)  horizontal -= horizontal_velocity_;
+    if (move_right_) horizontal += horizontal_velocity_;
+  }
+
+  velocity.x = horizontal + knockback_velocity_.x;
+  velocity.y += knockback_velocity_.y;
+
+  is_walking_ = (horizontal != 0.0f);
+
+  if (crouch_ && is_grounded_) {
+    if (!is_crouching_) {
+      col.height(default_crouching_height_);
+      col.offset(default_crouching_offset_);
+    }
     is_crouching_ = true;
-    is_walking_ = false;
-  } else if (!crouch_ && is_crouching_) {
-    box_collider.offset(default_standing_offset_);
-    box_collider.height(default_standing_height_);
+  } else {
+    if (is_crouching_) {
+      col.height(default_standing_height_);
+      col.offset(default_standing_offset_);
+    }
     is_crouching_ = false;
   }
 
-  float velocity_x = 0.0f;
-  float applied_force_y = crouch_ ? dropping_speed_ : 0.0f;
-
-  if (!is_crouching_) {
-    if (move_left_)  velocity_x -= horizontal_velocity_;
-    if (move_right_) velocity_x += horizontal_velocity_;
+  if (jump_) {
+    if (is_grounded_) {
+      force.y = -jumping_force_;
+      is_grounded_ = false;
+      is_double_jumping_ = false;
+    }
+    else if (!is_double_jumping_) {
+      force.y = -double_jump_force_;
+      is_double_jumping_ = true;
+    }
   }
 
-  // Decide if moving
-  is_walking_ = (move_left_ || move_right_) && !is_crouching_;
-
-  const float current_velocity_y = rigidbody.velocity().y;
-  if (jump_ && !is_jumping_) {
-    if (std::abs(current_velocity_y) < velocity_y_threshold_)
-      rigidbody.velocity({ rigidbody.velocity().x, 0.0f, rigidbody.velocity().z });
-
-    applied_force_y -= jumping_force_;
-    is_jumping_ = true;
-  } else if (jump_ && !is_double_jumping_) {
-    const float abs_velocity_y = std::abs(current_velocity_y);
-    if (abs_velocity_y < velocity_y_threshold_)
-      rigidbody.velocity({ rigidbody.velocity().x, 0.0f, rigidbody.velocity().z });
-
-    applied_force_y -= double_jump_force_;
-    // To make double jump feel smoother, we apply less force if the player is
-    // already moving upwards
-    applied_force_y += std::clamp(current_velocity_y, 0.0f, velocity_y_threshold_);
-
-    is_double_jumping_ = true;
+  // Optional fast-fall
+  if (crouch_ && !is_grounded_) {
+    force.y += dropping_speed_;
+    is_crouching_ = true;
   }
 
-  Vector3 velocity = rigidbody.velocity();
-  velocity.x = velocity_x;
-  rigidbody.velocity(velocity);
-  rigidbody.apply_force({0, applied_force_y, 0});
+  rb.velocity(velocity);
+  rb.apply_force(force);
+
+  knockback_velocity_ -= knockback_velocity_ * knockback_decay_ * latest_dt_;
+
+  if (knockback_velocity_.length() < 0.01f) {
+    knockback_velocity_ = {0, 0, 0};
+  }
 }
 
-void PlayerMovementBehavior::update_animation()
-{
+
+void PlayerMovementBehavior::update_animation() {
   auto& animator = animator_opt_->get();
   auto& sprite   = sprite_opt_->get();
 
-  if (is_crouching_) {
-    sprite.texture("capybara_default_duck");
-    animator.pause();
+  if (crouch_) {
+    sprite.texture(PlayerConstants::CROUCHING_TEXTURE);
     return;
   }
 
-  sprite.texture("capybara_default_idle");
-  if (is_walking_) {
-    animator.play(PlayerConstants::WALKING_ANIMATION, true);
-  } else {
-    animator.pause();
+  if ((jump_ || is_double_jumping_) && !is_grounded_) {
+    sprite.texture(PlayerConstants::JUMPING_TEXTURE);
+    return;
   }
 
-  if (move_left_) sprite.flip_x(true);
+  if (is_walking_ && is_grounded_ && !animator.is_playing()) {
+    animator.play(PlayerConstants::WALKING_ANIMATION, true);
+  }
+
+  if (!crouch_ && !is_walking_ && is_grounded_) {
+    animator.pause();
+    sprite.texture(PlayerConstants::IDLE_TEXTURE);
+  }
+
+  if (move_left_)  sprite.flip_x(true);
   if (move_right_) sprite.flip_x(false);
 }
+
 
 void PlayerMovementBehavior::send_movement_if_needed(const std::vector<PlayerMovementTypes>& movement) {
   // If we're not detecting any input, send one final message stating that we are no longer moving.
@@ -279,3 +310,8 @@ bool PlayerMovementBehavior::is_double_jumping() const {
 }
 bool PlayerMovementBehavior::is_walking() const {
   return is_walking_; }
+
+void PlayerMovementBehavior::apply_knockback(const Point& force) {
+  knockback_velocity_.x += force.x;
+  knockback_velocity_.y += force.y;
+}

--- a/src/character/player_movement_behavior.cpp
+++ b/src/character/player_movement_behavior.cpp
@@ -1,12 +1,12 @@
-#include "engine/core/engine.h"
-#include "engine/core/rendering/assetService.h"
-#include "engine/input/i_input_provider.h"
-#include "engine/input/input_manager.h"
-#include <engine/network/multiplayer_service.h>
-
+#include <game/character/player_movement_behavior.h>
 #include <game/network/message_types.h>
 #include <game/character/playerConstants.h>
-#include <game/character/player_movement_behavior.h>
+
+#include <engine/core/engine.h>
+#include <engine/core/rendering/assetService.h>
+#include <engine/input/i_input_provider.h>
+#include <engine/input/input_manager.h>
+#include <engine/network/multiplayer_service.h>
 
 PlayerMovementBehavior::PlayerMovementBehavior()
     : PlayerMovementBehavior(32.0f, 18.0f, {}, {}) {}
@@ -14,7 +14,7 @@ PlayerMovementBehavior::PlayerMovementBehavior()
 PlayerMovementBehavior::PlayerMovementBehavior(
     const float default_standing_height, const float default_crouching_height,
     const Point default_standing_offset, const Point default_crouching_offset)
-    : PlayerMovementBehavior(30.0f, 8.0f, 1.5f, 6.0f, 18.0f,
+    : PlayerMovementBehavior(30.0f, 25.0f, 120.0f, 35.0f,
                              default_standing_height, default_crouching_height,
                              default_standing_offset,
                              default_crouching_offset) {}
@@ -22,8 +22,8 @@ PlayerMovementBehavior::PlayerMovementBehavior(
 PlayerMovementBehavior::PlayerMovementBehavior(
     const float horizontal_velocity, const float jumping_force,
     const float dropping_speed, const float double_jump_force,
-    const float velocity_y_threshold, const float default_standing_height,
-    const float default_crouching_height, const Point default_standing_offset, const Point default_crouching_offset)
+    const float default_standing_height, const float default_crouching_height,
+    const Point default_standing_offset, const Point default_crouching_offset)
     : Behavior(),
       // Required components
       rigidbody_opt_(std::nullopt), animator_opt_(std::nullopt),
@@ -32,7 +32,7 @@ PlayerMovementBehavior::PlayerMovementBehavior(
       // Configurable params for movement physics
       horizontal_velocity_(horizontal_velocity), jumping_force_(jumping_force),
       dropping_speed_(dropping_speed), double_jump_force_(double_jump_force),
-      velocity_y_threshold_(velocity_y_threshold), knockback_decay_(7.0f),
+      knockback_decay_(7.0f),
 
       // State flags
       is_grounded_(false), is_crouching_(false), is_jumping_(false),
@@ -52,6 +52,8 @@ void PlayerMovementBehavior::on_start() {
   sprite_opt_       = get_component<Sprite>();
   box_collider_opt_ = get_component<BoxCollider2D>();
 
+  rigidbody_opt_->get().gravity_scale(3.0f);
+
   if (!player_has_required_components()) {
     throw std::runtime_error("PlayerMovementBehavior missing components");
   }
@@ -66,8 +68,6 @@ void PlayerMovementBehavior::on_start() {
       is_grounded_ = true;
       is_jumping_ = false;
       is_double_jumping_ = false;
-
-      self.friction(0.6f);
     });
 
   collider.add_on_collision_exit(
@@ -82,20 +82,12 @@ bool PlayerMovementBehavior::player_has_required_components() const {
          sprite_opt_.has_value() && box_collider_opt_.has_value();
 }
 
-void PlayerMovementBehavior::set_local_player() noexcept {
-  is_local_player_ = true;
-}
-
-void PlayerMovementBehavior::set_controllable() noexcept {
-  is_controllable_ = true;
-}
-
 void PlayerMovementBehavior::on_update(float dt) {
   latest_dt_ = dt;
 
   if (!is_controllable_) {
-    apply_physics({});
-    update_animation();
+    apply_physics();
+    apply_animation();
     return;
   }
 
@@ -104,17 +96,18 @@ void PlayerMovementBehavior::on_update(float dt) {
 
   handle_movement(movement);
 
-  if (is_local_player_)
-    send_movement_if_needed(movement);
+  if (is_local_player_) send_movement_if_needed(movement);
 }
 
+void PlayerMovementBehavior::set_local_player() noexcept { is_local_player_ = true; }
+void PlayerMovementBehavior::set_controllable() noexcept { is_controllable_ = true; }
 
 void PlayerMovementBehavior::handle_movement(
   const std::vector<PlayerMovementTypes>& movement
 ) {
   set_movement_flags(movement);
-  apply_physics(movement);
-  update_animation();
+  apply_physics();
+  apply_animation();
 }
 
 
@@ -139,7 +132,6 @@ void PlayerMovementBehavior::gather_input(
     movement.push_back(PlayerMovementTypes::JUMP);
 }
 
-
 void PlayerMovementBehavior::set_movement_flags(
   const std::vector<PlayerMovementTypes>& movement
 ) {
@@ -154,9 +146,7 @@ void PlayerMovementBehavior::set_movement_flags(
   jump_       = has(movement, PlayerMovementTypes::JUMP);
 }
 
-void PlayerMovementBehavior::apply_physics(
-  const std::vector<PlayerMovementTypes>& movement
-) {
+void PlayerMovementBehavior::apply_physics() {
   if (!player_has_required_components())
     return;
 
@@ -164,19 +154,21 @@ void PlayerMovementBehavior::apply_physics(
   auto& col = box_collider_opt_->get();
 
   Vector3 velocity = rb.velocity();
-  Vector3 force = {};
 
-  float horizontal = 0.0f;
+  /// Horizontal movement
+  float input_x = 0.0f;
+
   if (!is_crouching_) {
-    if (move_left_)  horizontal -= horizontal_velocity_;
-    if (move_right_) horizontal += horizontal_velocity_;
+    if (move_left_)  input_x -= 1.0f;
+    if (move_right_) input_x += 1.0f;
   }
 
-  velocity.x = horizontal + knockback_velocity_.x;
-  velocity.y += knockback_velocity_.y;
+  float desired_horizontal = input_x * horizontal_velocity_;
+  velocity.x = desired_horizontal + knockback_velocity_.x;
 
-  is_walking_ = (horizontal != 0.0f);
+  is_walking_ = (input_x != 0.0f && is_grounded_);
 
+  /// Crouching
   if (crouch_ && is_grounded_) {
     if (!is_crouching_) {
       col.height(default_crouching_height_);
@@ -191,36 +183,34 @@ void PlayerMovementBehavior::apply_physics(
     is_crouching_ = false;
   }
 
+  /// Vertical movement (jumping)
   if (jump_) {
     if (is_grounded_) {
-      force.y = -jumping_force_;
+      velocity.y = -jumping_force_;
       is_grounded_ = false;
       is_double_jumping_ = false;
     }
     else if (!is_double_jumping_) {
-      force.y = -double_jump_force_;
+      velocity.y = -double_jump_force_;
       is_double_jumping_ = true;
     }
   }
+  
+  velocity.y += knockback_velocity_.y;
 
-  // Optional fast-fall
-  if (crouch_ && !is_grounded_) {
-    force.y += dropping_speed_;
-    is_crouching_ = true;
+  if (crouch_) {
+    velocity.y += dropping_speed_ * latest_dt_;
   }
 
   rb.velocity(velocity);
-  rb.apply_force(force);
-
   knockback_velocity_ -= knockback_velocity_ * knockback_decay_ * latest_dt_;
 
   if (knockback_velocity_.length() < 0.01f) {
-    knockback_velocity_ = {0, 0, 0};
+    knockback_velocity_ = {0.f, 0.f, 0.f};
   }
 }
 
-
-void PlayerMovementBehavior::update_animation() {
+void PlayerMovementBehavior::apply_animation() {
   auto& animator = animator_opt_->get();
   auto& sprite   = sprite_opt_->get();
 
@@ -273,43 +263,22 @@ void PlayerMovementBehavior::send_movement_if_needed(const std::vector<PlayerMov
   multiplayer_service.send(msg);
 }
 
-float PlayerMovementBehavior::horizontal_velocity() const {
-  return horizontal_velocity_;
-}
-void PlayerMovementBehavior::horizontal_velocity(const float speed) {
-  horizontal_velocity_ = speed;
-}
-float PlayerMovementBehavior::jumping_force() const {
-  return jumping_force_; }
-void PlayerMovementBehavior::jumping_force(const float speed) {
-  jumping_force_ = speed;
-}
-float PlayerMovementBehavior::dropping_speed() const {
-  return dropping_speed_; }
-void PlayerMovementBehavior::dropping_speed(const float speed) {
-  dropping_speed_ = speed;
-}
-float PlayerMovementBehavior::double_jump_force() const {
-  return double_jump_force_;
-}
-void PlayerMovementBehavior::double_jump_force(const float speed) {
-  double_jump_force_ = speed;
-}
-float PlayerMovementBehavior::velocity_y_threshold() const {
-  return velocity_y_threshold_;
-}
-void PlayerMovementBehavior::velocity_y_threshold(const float threshold) {
-  velocity_y_threshold_ = threshold;
-}
-bool PlayerMovementBehavior::is_crouching() const {
-  return is_crouching_; }
-bool PlayerMovementBehavior::is_jumping() const {
-  return is_jumping_; }
-bool PlayerMovementBehavior::is_double_jumping() const {
-  return is_double_jumping_;
-}
-bool PlayerMovementBehavior::is_walking() const {
-  return is_walking_; }
+float PlayerMovementBehavior::horizontal_velocity() const { return horizontal_velocity_; }
+void PlayerMovementBehavior::horizontal_velocity(const float speed) { horizontal_velocity_ = speed; }
+
+float PlayerMovementBehavior::jumping_force() const { return jumping_force_; }
+void PlayerMovementBehavior::jumping_force(const float speed) { jumping_force_ = speed; }
+
+float PlayerMovementBehavior::dropping_speed() const { return dropping_speed_; }
+void PlayerMovementBehavior::dropping_speed(const float speed) { dropping_speed_ = speed; }
+
+float PlayerMovementBehavior::double_jump_force() const { return double_jump_force_; }
+void PlayerMovementBehavior::double_jump_force(const float speed) { double_jump_force_ = speed; }
+
+bool PlayerMovementBehavior::is_crouching() const { return is_crouching_; }
+bool PlayerMovementBehavior::is_jumping() const { return is_jumping_; }
+bool PlayerMovementBehavior::is_double_jumping() const { return is_double_jumping_; }
+bool PlayerMovementBehavior::is_walking() const { return is_walking_; }
 
 void PlayerMovementBehavior::apply_knockback(const Point& force) {
   knockback_velocity_.x += force.x;

--- a/src/character/player_object.cpp
+++ b/src/character/player_object.cpp
@@ -29,7 +29,7 @@ PlayerObject::PlayerObject(Scene &scene, const Vector3 initial_pos, bool is_loca
   const Point default_offset = {default_x_offset, 4 * scale_factor};
 
   this->add_component<Rigidbody2D>(BodyType2D::Type::Dynamic, 35.0f);
-  this->add_component<BoxCollider2D>(0.1f, 0.2f, 20 * scale_factor,
+  this->add_component<BoxCollider2D>(0.1f, .0f, 20 * scale_factor,
                                      default_height, default_offset);
 
   this->add_component<BehaviorScript>(std::make_unique<PlayerController>(100, 100));

--- a/src/character/player_object.cpp
+++ b/src/character/player_object.cpp
@@ -28,8 +28,8 @@ PlayerObject::PlayerObject(Scene &scene, const Vector3 initial_pos, bool is_loca
   constexpr float default_x_offset = 6 * scale_factor;
   const Point default_offset = {default_x_offset, 4 * scale_factor};
 
-  this->add_component<Rigidbody2D>(BodyType2D::Type::Dynamic, 35.0f);
-  this->add_component<BoxCollider2D>(0.1f, .0f, 20 * scale_factor,
+  this->add_component<Rigidbody2D>(BodyType2D::Type::Dynamic, 35.0f, true, 3.0f);
+  this->add_component<BoxCollider2D>(0.6f, .0f, 20 * scale_factor,
                                      default_height, default_offset);
 
   this->add_component<BehaviorScript>(std::make_unique<PlayerController>(100, 100));

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -44,7 +44,7 @@ void Game::initialize() {
         {"character/capybara_default_idle.png", "capybara_default_idle", 1, 1},
         {"character/capybara_default_duck.png", "capybara_default_duck", 1, 1},
         {"character/capybara_default_jump.png", "capybara_default_jump", 1, 1},
-        {"character/capybara_default_dead.png", "capybara_default_dead", 1, 1},
+        {"character/capybara_default_death.png", "capybara_default_death", 1, 1},
         {"character/capybara_default_hit.png", "capybara_default_hit", 1, 1},
         {"character/capybara_default_walk_anim.png", "capybara_default_walk_anim_sheet", 1, 8},
         {"character/capybara_default_idle_anim.png", "capybara_default_idle_anim_sheet", 1, 7},

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -43,6 +43,9 @@ void Game::initialize() {
         // Characters
         {"character/capybara_default_idle.png", "capybara_default_idle", 1, 1},
         {"character/capybara_default_duck.png", "capybara_default_duck", 1, 1},
+        {"character/capybara_default_jump.png", "capybara_default_jump", 1, 1},
+        {"character/capybara_default_dead.png", "capybara_default_dead", 1, 1},
+        {"character/capybara_default_hit.png", "capybara_default_hit", 1, 1},
         {"character/capybara_default_walk_anim.png", "capybara_default_walk_anim_sheet", 1, 8},
         {"character/capybara_default_idle_anim.png", "capybara_default_idle_anim_sheet", 1, 7},
         {"character/capybara_default_jump_anim.png", "capybara_default_jump_anim_sheet", 1, 7},

--- a/src/prefabs/weapons/weapon_axe_player_object.cpp
+++ b/src/prefabs/weapons/weapon_axe_player_object.cpp
@@ -34,7 +34,8 @@ WeaponAxePlayerObject::WeaponAxePlayerObject(Scene& scene, GameObject& parent)
 
     const int damage = 40;
     const int range = 20;
-    const Point knockback_force = Point{200.0f, 100.0f};
+    const Point knockback_force = Point{24.0f, -1.5f};
+
 
     const Point hitbox_offset{60, 0};
     const Point sprite_offset_left{-5.0f, 0};

--- a/src/prefabs/weapons/weapon_bat_player_object.cpp
+++ b/src/prefabs/weapons/weapon_bat_player_object.cpp
@@ -34,7 +34,7 @@ WeaponBatPlayerObject::WeaponBatPlayerObject(Scene& scene, GameObject& parent)
 
     const int damage = 10;
     const int range = 20;
-    const Point knockback_force = Point{300.0f, 50.0f};
+    const Point knockback_force = Point{24.0f, -1.0f};
 
     const Point hitbox_offset{60, 0};
     const Point sprite_offset_left{30.0f, 0};

--- a/src/prefabs/weapons/weapon_boxing_gloves_player_object.cpp
+++ b/src/prefabs/weapons/weapon_boxing_gloves_player_object.cpp
@@ -34,7 +34,8 @@ WeaponBoxingGlovesPlayerObject::WeaponBoxingGlovesPlayerObject(Scene& scene, Gam
 
     const int damage = 5;
     const int range = 20;
-    const Point knockback_force = Point{10.0f, -0.5f};
+    const Point knockback_force = Point{30.0f, -1.5f};
+    // const Point knockback_force = Point{16.0f, -1.0f};
 
     const Point hitbox_offset{60, 0};
     const Point sprite_offset_left{-10.0f, 15.0f};

--- a/src/prefabs/weapons/weapon_boxing_gloves_player_object.cpp
+++ b/src/prefabs/weapons/weapon_boxing_gloves_player_object.cpp
@@ -34,7 +34,7 @@ WeaponBoxingGlovesPlayerObject::WeaponBoxingGlovesPlayerObject(Scene& scene, Gam
 
     const int damage = 5;
     const int range = 20;
-    const Point knockback_force = Point{600.0f, 200.0f};
+    const Point knockback_force = Point{10.0f, -0.5f};
 
     const Point hitbox_offset{60, 0};
     const Point sprite_offset_left{-10.0f, 15.0f};

--- a/src/prefabs/weapons/weapon_sword_player_object.cpp
+++ b/src/prefabs/weapons/weapon_sword_player_object.cpp
@@ -34,7 +34,8 @@ WeaponSwordPlayerObject::WeaponSwordPlayerObject(Scene& scene, GameObject& paren
 
     const int damage = 20;
     const int range = 25;
-    const Point knockback_force = Point{200.0f, 50.0f};
+    const Point knockback_force = Point{16.0f, -1.0f};
+
 
     const Point hitbox_offset{60, 0};
     const Point sprite_offset_left{15.0f, 0};

--- a/src/scenes/level_loader.cpp
+++ b/src/scenes/level_loader.cpp
@@ -196,6 +196,7 @@ void LevelLoader::create_tile_colliders(Scene& scene, const json& tiles_json) {
                     "MergedCollider_G" + std::to_string(group) +
                     "_Y" + std::to_string(row)
                 );
+                collider_obj.tag("Ground");
                 collider_obj.transform().position({
                     first.world_x,
                     first.world_y,
@@ -208,7 +209,7 @@ void LevelLoader::create_tile_colliders(Scene& scene, const json& tiles_json) {
                     1.0f
                 );
                 collider_obj.add_component<BoxCollider2D>(
-                    0.5f,
+                    0.f,
                     0.0f,
                     merged_width,
                     first.height,


### PR DESCRIPTION
>[!WARNING] [gravity fix](https://github.com/SPC-F/CapycoreEngine/pull/176) should be merged first as that is a missing piece
>I placed a comment on the line that should be removed once this is patched

This PR refactors the movement so it moves cleaner and more responsive. Besides that I also fixed the sliding problem and made it easier to read.

Take note that I scaled the mass and gravity up for the player now. He is heavier but moves more fluently. I based it off hollow knight's movement.

Networking should still work fine as I just shifted stuff and did not touch any serialization part.