### PR TITLE
feat (player): add hit and dying animations

### DIFF
--- a/include/game/behaviors/dying_capybara_behavior.h
+++ b/include/game/behaviors/dying_capybara_behavior.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <engine/public/behavior.h>
+
+class DyingCapybaraBehavior : public Behavior {
+public:
+    DyingCapybaraBehavior(float disappear_time);
+    ~DyingCapybaraBehavior() override = default;    
+
+    void on_awake() override;
+    void on_update(float dt) override;
+
+private: 
+    float time_before_disappear_{2.0f};
+    float accumulated_time_{0.0f};
+};

--- a/include/game/character/playerConstants.h
+++ b/include/game/character/playerConstants.h
@@ -5,7 +5,7 @@ namespace PlayerConstants {
     constexpr auto IDLE_ANIMATION = "capybara_default_idle_anim";
     constexpr auto JUMPING_ANIMATION = "capybara_default_jump_anim";
     constexpr auto CROUCHING_ANIMATION = "capybara_default_duck_anim";
-    constexpr auto DEATH_ANIMATION = "capybara_default_dead_anim";
+    constexpr auto DEATH_ANIMATION = "capybara_default_death_anim";
     constexpr auto HIT_ANIMATION = "capybara_default_hit_anim";
 
     constexpr auto IDLE_TEXTURE = "capybara_default_idle";

--- a/include/game/character/player_controller.h
+++ b/include/game/character/player_controller.h
@@ -23,8 +23,6 @@ public:
   explicit PlayerController(int max_health, int start_health);
   ~PlayerController() override = default;
 
-  void on_awake() override;
-  void on_start() override;
   void on_update(float dt) override;
 
   [[nodiscard]] int health() const;
@@ -43,6 +41,8 @@ public:
 
   [[nodiscard]] bool is_soft_dead() const;
   [[nodiscard]] bool is_hard_dead() const;
+
+  void hit(int damage);
 
   void on_destroy() override;
 };

--- a/include/game/character/player_movement_behavior.h
+++ b/include/game/character/player_movement_behavior.h
@@ -103,4 +103,5 @@ public:
   void double_jump_force(const float speed);
 
   void apply_knockback(const Point& force);
+  void reset_knockback();
 };

--- a/include/game/prefabs/character/dying_capybara_object.h
+++ b/include/game/prefabs/character/dying_capybara_object.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <engine/public/gameObject.h>
+#include <engine/public/util/vector3.h>
+
+class DyingCapybaraObject final : public GameObject {
+public:
+  explicit DyingCapybaraObject(Scene& scene, Vector3 position, float disappear_time = 2.0f);
+  ~DyingCapybaraObject() override = default;
+
+private:
+    float disappear_time_;
+    float elapsed_time_{0.0f};
+};

--- a/include/game/round/roundcontroller.h
+++ b/include/game/round/roundcontroller.h
@@ -15,13 +15,19 @@ class RoundController final : public Behavior {
 private:
   std::mt19937 gen_{std::random_device{}()};
   size_t last_spawn_index_ = 0;
+  Vector3 spawn_position_;
 
   std::vector<round_end_callback_t> round_end_callbacks;
   std::vector<std::reference_wrapper<PlayerObject>> players;
   std::map<std::string, lib::Subscription> on_player_health_changed_subscriptions;
   std::vector<Vector3> spawn_positions_;
-
+  
+  void generate_new_spawn_position();
   void on_player_death(const PlayerObject &player);
+
+  void spawn_dead_player(const PlayerObject &player, Vector3 spawn_position);
+  void spawn_respawn_platform(const Vector3 &position, Vector3 spawn_position);
+
   void round_end() const;
 
 public:

--- a/src/behaviors/dying_capybara_behavior.cpp
+++ b/src/behaviors/dying_capybara_behavior.cpp
@@ -1,0 +1,29 @@
+#include <game/behaviors/dying_capybara_behavior.h>
+
+#include <engine/public/components/animator.h>
+#include <engine/public/components/colliders/box_collider_2d.h>
+#include <engine/public/components/rigidbody_2d.h>
+#include <engine/public/components/sprite.h>
+
+DyingCapybaraBehavior::DyingCapybaraBehavior(float disappear_time)
+    : time_before_disappear_(disappear_time) {}
+
+void DyingCapybaraBehavior::on_awake() {
+    auto maybe_animator = get_component<Animator>();
+    if (maybe_animator) {
+        auto& animator = maybe_animator->get();
+        animator.play(false);
+    }
+}
+
+void DyingCapybaraBehavior::on_update(float dt) {
+    accumulated_time_ += dt;
+
+    auto maybe_rigidbody = get_component<Rigidbody2D>();
+    if (maybe_rigidbody) {
+        auto& rb = maybe_rigidbody->get();
+        rb.velocity({0.0f, rb.velocity().y, 0.0f});
+    }
+
+    if (accumulated_time_ >= time_before_disappear_) game_object().mark_for_deletion();
+}

--- a/src/behaviors/weapon_melee_behavior.cpp
+++ b/src/behaviors/weapon_melee_behavior.cpp
@@ -73,7 +73,7 @@ void WeaponMeleeBehavior::on_awake() {
                     auto& behavior = behavior_ref.get().behavior();
                     
                     if (auto ctrl = dynamic_cast<PlayerController*>(&behavior); ctrl != nullptr) {
-                        ctrl->damage(damage_);
+                        ctrl->hit(damage_);
                     }
                     
                     if (auto movement = dynamic_cast<PlayerMovementBehavior*>(&behavior); movement != nullptr) {

--- a/src/behaviors/weapon_melee_behavior.cpp
+++ b/src/behaviors/weapon_melee_behavior.cpp
@@ -69,18 +69,32 @@ void WeaponMeleeBehavior::on_awake() {
                 auto& other_gameobject = other_parent_opt->get();
                 if (other_gameobject.tag() != "Player" || other_gameobject.id() == player_component_->get().id()) return;
 
+                std::optional<std::reference_wrapper<PlayerController>> controller_opt;
+                std::optional<std::reference_wrapper<PlayerMovementBehavior>> movement_opt;
+
                 auto behaviors = other_gameobject.get_components<BehaviorScript>();
                 for (auto& behavior_ref : behaviors) {
                     auto& behavior = behavior_ref.get().behavior();
                     
-                    if (auto ctrl = dynamic_cast<PlayerController*>(&behavior); ctrl != nullptr) {
-                        ctrl->hit(damage_);
+                    if (auto ctrl = dynamic_cast<PlayerController*>(&behavior); ctrl != nullptr) controller_opt = *ctrl;
+                    if (auto movement = dynamic_cast<PlayerMovementBehavior*>(&behavior); movement != nullptr) movement_opt = *movement;
+                }
+
+                bool should_reset_knockback = false;
+
+                if (controller_opt.has_value()) {
+                    should_reset_knockback = controller_opt->get().health() - damage_ <= 0;
+                    controller_opt->get().hit(damage_);
+                }
+
+                if (movement_opt.has_value()) {
+                    if (should_reset_knockback) {
+                        movement_opt->get().reset_knockback();
+                        return;
                     }
-                    
-                    if (auto movement = dynamic_cast<PlayerMovementBehavior*>(&behavior); movement != nullptr) {
-                        Point knockback = facing_right_ ? knockback_force_ : Point{-knockback_force_.x, knockback_force_.y};
-                        movement->apply_knockback(knockback);
-                    }
+
+                    Point knockback = facing_right_ ? knockback_force_ : Point{-knockback_force_.x, knockback_force_.y};
+                    movement_opt->get().apply_knockback(knockback);
                 }
             }
         });

--- a/src/character/player_controller.cpp
+++ b/src/character/player_controller.cpp
@@ -1,12 +1,16 @@
 
-#include <engine/util/uuid.h>
 #include <game/character/player_controller.h>
+#include <game/character/playerConstants.h>
+#include <game/prefabs/character/dying_capybara_object.h>
+
+#include <engine/public/scene.h>
+#include <engine/public/components/sprite.h>
+#include <engine/public/components/animator.h>
+#include <engine/util/uuid.h>
 
 PlayerController::PlayerController(): PlayerController(100, 100) {}
 PlayerController::PlayerController(const int max_health, const int start_health): max_health_(max_health), health_ { start_health }, lives_(3) {}
 
-void PlayerController::on_awake() {}
-void PlayerController::on_start() {}
 void PlayerController::on_update(float dt) {}
 
 int PlayerController::health() const {
@@ -82,6 +86,17 @@ bool PlayerController::is_hard_dead() const {
 
 bool PlayerController::is_soft_dead() const {
   return lives_ >= 1 && health_ <= 0;
+}
+
+void PlayerController::hit(int damage) {
+  auto animator = get_component<Animator>();
+  
+  if (animator) {
+    animator->get().is_non_interruptible(true);
+    animator->get().play(PlayerConstants::HIT_ANIMATION, false);
+  }
+
+  this->damage(damage);
 }
 
 void PlayerController::on_destroy() {

--- a/src/character/player_movement_behavior.cpp
+++ b/src/character/player_movement_behavior.cpp
@@ -206,6 +206,8 @@ void PlayerMovementBehavior::apply_animation() {
   auto& animator = animator_opt_->get();
   auto& sprite   = sprite_opt_->get();
 
+  if (animator.is_non_interruptible()) return;
+
   if (crouch_) {
     sprite.texture(PlayerConstants::CROUCHING_TEXTURE);
     return;

--- a/src/character/player_movement_behavior.cpp
+++ b/src/character/player_movement_behavior.cpp
@@ -278,3 +278,7 @@ void PlayerMovementBehavior::apply_knockback(const Point& force) {
   knockback_velocity_.x += force.x;
   knockback_velocity_.y += force.y;
 }
+
+void PlayerMovementBehavior::reset_knockback() {
+  knockback_velocity_ = {0.f, 0.f, 0.f};
+}

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -48,6 +48,8 @@ void Game::initialize() {
         {"character/capybara_default_jump.png", "capybara_default_jump", 1, 1},
         {"character/capybara_default_death.png", "capybara_default_death", 1, 1},
         {"character/capybara_default_hit.png", "capybara_default_hit", 1, 1},
+        {"character/capybara_default_hit_anim.png", "capybara_default_hit_anim_sheet", 1, 8},
+        {"character/capybara_default_death_anim.png", "capybara_default_death_anim_sheet", 1, 8},
         {"character/capybara_default_walk_anim.png", "capybara_default_walk_anim_sheet", 1, 8},
         {"character/capybara_default_idle_anim.png", "capybara_default_idle_anim_sheet", 1, 7},
         {"character/capybara_default_jump_anim.png", "capybara_default_jump_anim_sheet", 1, 7},
@@ -244,6 +246,8 @@ void Game::initialize() {
         {"capybara_default_idle_anim_sheet", "capybara_default_idle_anim", 0, 7},
         {"capybara_default_jump_anim_sheet", "capybara_default_jump_anim", 0, 7},
         {"capybara_default_duck_anim_sheet", "capybara_default_duck_anim", 0, 7},
+        {"capybara_default_death_anim_sheet", "capybara_default_death_anim", 0, 7},
+        {"capybara_default_hit_anim_sheet", "capybara_default_hit_anim", 0, 7},
 
         // Opponents
         {"drone_idle_anim_sheet", "drone_idle_anim", 0, 7},

--- a/src/prefabs/character/dying_capybara_object.cpp
+++ b/src/prefabs/character/dying_capybara_object.cpp
@@ -1,0 +1,29 @@
+#include <game/prefabs/character/dying_capybara_object.h>
+#include <game/behaviors/ui/main_menu/main_menu_fall_behavior.h>
+#include <game/behaviors/dying_capybara_behavior.h>
+#include <game/character/playerConstants.h>
+
+#include <engine/public/scene.h>
+#include <engine/public/components/animator.h>
+#include <engine/public/components/behaviorscript.h>
+#include <engine/public/components/colliders/box_collider_2d.h>
+#include <engine/public/components/rigidbody_2d.h>
+#include <engine/public/components/sprite.h>
+
+constexpr float size_modifier = 2.0f;
+
+DyingCapybaraObject::DyingCapybaraObject(Scene& scene, Vector3 position, float disappear_time)
+: GameObject(scene),
+  disappear_time_(disappear_time)
+  {
+    this->name("Dying_Capybara_Object");
+    this->transform().scale({size_modifier, size_modifier, 1.0f});
+    this->transform().position(position);
+    this->layer(Layers::Foreground);
+    
+    this->add_component<Sprite>(PlayerConstants::IDLE_TEXTURE, Color{255, 255, 255, 255}, 0, 0, 0, 0);
+    this->add_component<Animator>(PlayerConstants::DEATH_ANIMATION, 65);
+    this->add_component<BehaviorScript>(std::make_unique<DyingCapybaraBehavior>(disappear_time_));
+    this->add_component<Rigidbody2D>(BodyType2D::Dynamic, 30.0f, true, 3.0f);
+    this->add_component<BoxCollider2D>(1.0f, 1.0f, 32.0f * size_modifier, 16.0f * size_modifier, Point{0.0f, 16.0f * size_modifier});
+}

--- a/src/round/roundcontroller.cpp
+++ b/src/round/roundcontroller.cpp
@@ -52,30 +52,31 @@ void RoundController::add_player(PlayerObject &player) {
 }
 
 void RoundController::on_player_death(const PlayerObject &player) {
+  std::optional<std::reference_wrapper<PlayerController>> controller_opt;
+
   for (auto behavior : player.get_components<BehaviorScript>()) {
-    const auto controller = dynamic_cast<PlayerController *>(&behavior.get().behavior());
-    if (!controller) {
-      continue;
+    if (auto pc = dynamic_cast<PlayerController *>(&behavior.get().behavior())) {
+      controller_opt = *pc;
     }
+  }
 
-    controller->lives(controller->lives() - 1);
+  if (!controller_opt.has_value()) return;
+  auto controller = &controller_opt->get();
 
-    if (controller->lives() < 1) {
-      return;
-    }
+  controller->lives(controller->lives() - 1);
+  if (controller->lives() < 1) return;
 
-    if (const auto& rigid_body_opt = player.get_component<Rigidbody2D>(); rigid_body_opt.has_value()) {
-      generate_new_spawn_position();
-      
-      spawn_dead_player(player, spawn_position_);
-      spawn_respawn_platform(player.transform().position(), spawn_position_);
-
-      auto& rigid_body = rigid_body_opt->get();
-      rigid_body.velocity({0, 0, 0});
-      rigid_body.teleport(spawn_position_);
-      
-      controller->health(controller->max_health());
-    }
+  if (const auto& rigid_body_opt = player.get_component<Rigidbody2D>(); rigid_body_opt.has_value()) {
+    generate_new_spawn_position();
+    
+    spawn_dead_player(player, spawn_position_);
+    spawn_respawn_platform(player.transform().position(), spawn_position_);
+   
+    auto& rigid_body = rigid_body_opt->get();
+    rigid_body.velocity({0, 0, 0});
+    rigid_body.teleport(spawn_position_);
+    
+    controller->health(controller->max_health());
   }
 }
 

--- a/src/round/roundcontroller.cpp
+++ b/src/round/roundcontroller.cpp
@@ -5,6 +5,7 @@
 
 #include <engine/public/scene.h>
 #include <engine/public/components/rigidbody_2d.h>
+#include <game/prefabs/character/dying_capybara_object.h>
 
 constexpr float RESPAWN_PLATFORM_X_OFFSET = 0.0f;
 constexpr float RESPAWN_PLATFORM_Y_OFFSET = 80.0f;
@@ -13,6 +14,20 @@ RoundController::RoundController(std::vector<Vector3> spawn_positions): Behavior
 
 void RoundController::on_awake() {}
 void RoundController::on_update(float dt) {}
+
+void RoundController::generate_new_spawn_position() {
+  std::uniform_int_distribution<size_t> distr(0, spawn_positions_.size() - 1);
+  size_t spawn_index = distr(gen_);
+
+  if (spawn_positions_.size() > 1) {
+    while (spawn_index == last_spawn_index_) {
+      spawn_index = distr(gen_);
+    }
+  }
+  last_spawn_index_ = spawn_index;
+
+  spawn_position_ = spawn_positions_[spawn_index];
+}
 
 void RoundController::add_player(PlayerObject &player) {
   for (auto behavior : player.get_components<BehaviorScript>()) {
@@ -44,27 +59,27 @@ void RoundController::on_player_death(const PlayerObject &player) {
     }
 
     if (const auto& rigid_body_opt = player.get_component<Rigidbody2D>(); rigid_body_opt.has_value()) {
-      std::uniform_int_distribution<size_t> distr(0, spawn_positions_.size() - 1);
-      size_t spawn_index = distr(gen_);
-
-      if (spawn_positions_.size() > 1) {
-        while (spawn_index == last_spawn_index_) {
-          spawn_index = distr(gen_);
-        }
-      }
-      last_spawn_index_ = spawn_index;
-
-      Vector3 spawn_position = spawn_positions_[spawn_index];
-      Vector3 platform_position = spawn_position + Vector3{RESPAWN_PLATFORM_X_OFFSET, RESPAWN_PLATFORM_Y_OFFSET, 0};
-      game_object().scene().add_game_object<CloudPlatformObject>(game_object().scene(), platform_position);
+      generate_new_spawn_position();
+      
+      spawn_dead_player(player, spawn_position_);
+      spawn_respawn_platform(player.transform().position(), spawn_position_);
 
       auto& rigid_body = rigid_body_opt->get();
-      rigid_body.teleport(spawn_position);
       rigid_body.velocity({0, 0, 0});
+      rigid_body.teleport(spawn_position_);
       
       controller->health(controller->max_health());
     }
   }
+}
+
+void RoundController::spawn_dead_player(const PlayerObject &player, Vector3 spawn_position) {
+  game_object().scene().add_game_object<DyingCapybaraObject>(game_object().scene(), player.transform().position(), 2.0f);  
+}
+
+void RoundController::spawn_respawn_platform(const Vector3 &position, Vector3 spawn_position) {
+  Vector3 platform_position = spawn_position + Vector3{RESPAWN_PLATFORM_X_OFFSET, RESPAWN_PLATFORM_Y_OFFSET, 0};
+  game_object().scene().add_game_object<CloudPlatformObject>(game_object().scene(), platform_position);
 }
 
 void RoundController::remove_player(PlayerObject &player) {


### PR DESCRIPTION
This adds both the hit and dying animations. The death animation is a seperate object. I could have altered the player object but that would just make things a bit more complex as we have a state where the player can't do anything. Instead I opted for a seperate object which just spawns and plays the death animation. This also makes it so there can be multiple bodies if players are killed in quick succession.

The bodies have physics, so they will fall, but they are only visible for 2 seconds and can't really be pushed around too much due to its weight.