### PR TITLE
fix (player): ghost movement due to empty init

### DIFF
--- a/include/game/character/player_movement_behavior.h
+++ b/include/game/character/player_movement_behavior.h
@@ -34,10 +34,10 @@ private:
   bool is_walking_;
 
   // Used when updating the player objects of peers during which we don't want to reset these states.
-  bool crouch_;
-  bool jump_;
-  bool move_left_;
-  bool move_right_;
+  bool crouch_{false};
+  bool jump_{false};
+  bool move_left_{false};
+  bool move_right_{false};
 
   bool send_empty_message_; // First message sent after no movement has been detected to clean animation states on peers
 


### PR DESCRIPTION
This fixes the player ghost movement due to an empty init on multiplayer variables