### PR TITLE
feat (game): add arguments to executable

### DIFF
--- a/include/game/game.h
+++ b/include/game/game.h
@@ -11,6 +11,10 @@
 class Game {
 public:
     void initialize();
+    
+    void set_fullscreen();
+    void set_resizable(float width, float height);
+    
     void run();
     void shutdown();
 private:

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -271,10 +271,7 @@ void Game::initialize() {
         {"./resources/sounds/player_jump.wav", "player_jump", SoundType::SDL_MIXER},
     };
     Assets::register_audio(audios);
-
-    auto& window_controller = engine.services->get_service<RenderingService>().get().window();
-    window_controller.set_window_fullscreen();
-
+    
     settings::apply_current_settings();
 
     levels_.emplace_back(std::make_unique<SwampScene>());
@@ -283,6 +280,18 @@ void Game::initialize() {
     for (auto& level : levels_) {
         level->init();
     }
+}
+
+void Game::set_fullscreen() {
+    auto& window_controller = Engine::instance().services->get_service<RenderingService>().get().window();
+    window_controller.set_window_fullscreen();
+}
+
+void Game::set_resizable(float width, float height) {
+    auto& window_controller = Engine::instance().services->get_service<RenderingService>().get().window();
+    window_controller.set_window_resizable();
+    window_controller.set_window_width(static_cast<unsigned>(width));
+    window_controller.set_window_height(static_cast<unsigned>(height));
 }
 
 void Game::run() {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -14,13 +14,55 @@
 //     #endif
 // }
 
+constexpr bool FULLSCREEN_DEFAULT = true;
+constexpr int WINDOW_WIDTH_DEFAULT = 1280;
+constexpr int WINDOW_HEIGHT_DEFAULT = 720;
+
+/// A simple command-line argument parser
+/// The following arguments are supported:
+/// --fullscreen            Launch the game in fullscreen mode (default)
+/// --resize                Launch the game in windowed mode
+/// --w <width>             Set the window width (only if --resize is used)
+/// --h <height>            Set the window height (only if --resize is used)
+void load_arguments(int argc, char** argv, bool& fullscreen, int& width, int& height) {
+    for (int i = 1; i < argc; ++i) {
+        std::string arg = argv[i];
+        if (arg == "--resize")                  fullscreen = false;
+        else if (arg == "--fullscreen")         fullscreen = true;
+        else if (arg == "--w" && i + 1 < argc)  width = std::stoi(argv[++i]);
+        else if (arg == "--h" && i + 1 < argc)  height = std::stoi(argv[++i]);
+    }
+}
+
 int main() {
     //tracy_init();
-    
+
+    bool fullscreen = FULLSCREEN_DEFAULT;
+    int width = WINDOW_WIDTH_DEFAULT;
+    int height = WINDOW_HEIGHT_DEFAULT;
+
+    int argc = 0;
+    char** argv = nullptr;
+
+    /// Cross-platform argc and argv
+    #ifdef _WIN32
+        argc = __argc;
+        argv = __argv;
+    #else
+        extern int argc;
+        extern char** argv;
+    #endif
+
+    load_arguments(argc, argv, fullscreen, width, height);
+
     Game game;
     try {
         game.initialize();
+
+        if (fullscreen)     game.set_fullscreen();
+        else                game.set_resizable(static_cast<float>(width), static_cast<float>(height));
         game.run();
+        
         game.shutdown();
     } catch (const std::exception& e) {
         std::cerr << "Unhandled exception: " << e.what() << std::endl;
@@ -28,6 +70,5 @@ int main() {
     }
 
     //tracy_shutdown();
-
     return 0;
 }


### PR DESCRIPTION
This PR wasn't really requested or needed, but I had some time over and figured this might be nice. When testing the multiplayer part it can be annoying to keep switching tabs, especially when you want to test stuff like syncing. Hence, we now have 4 launch params:

* `--resize`           (set resizable)
* `--fullscreen`     (set fullscreen and is the default)
* `--w <width>`   (set the default width)
* `--h <heigth>`  (set the default height)

Most of the times `--resize` is enough and `--h`/`--w` are extra options.