### PR TITLE
feat (roundend): add round end network message and return to menu

### DIFF
--- a/include/game/network/message_types.h
+++ b/include/game/network/message_types.h
@@ -11,6 +11,8 @@ enum class CustomMessageTypes : uint16_t {
     USER_RESPAWN,
     USER_DROP_WEAPON,
     DROP_SPAWN,
+
+    ROUND_END
 };
 
 struct MsgUserJoin {
@@ -46,4 +48,9 @@ struct MsgUserRespawn {
 
 struct MsgUserDropWeapon {
     char uuid[37];
+};
+
+struct MsgRoundEnd {
+    char winner_uuid[37];
+    bool draw;
 };

--- a/include/game/round/roundcontroller.h
+++ b/include/game/round/roundcontroller.h
@@ -18,6 +18,9 @@ private:
   size_t last_spawn_index_ = 0;
   Vector3 spawn_position_;
 
+  bool round_active_{true};
+  std::optional<std::reference_wrapper<PlayerObject>> winner_player_;
+
   std::vector<round_end_callback_t> round_end_callbacks;
   std::vector<std::reference_wrapper<PlayerObject>> players;
   std::map<std::string, lib::Subscription> on_player_health_changed_subscriptions;
@@ -30,21 +33,22 @@ private:
   void spawn_dead_player(const PlayerObject &player);
   void spawn_respawn_platform(const Vector3 &position, Vector3 spawn_position);
 
-  void round_end() const;
+  void check_round_end_conditions();
   void realign_player_info_positions();
 
 public:
   explicit RoundController(std::vector<Vector3> spawn_positions);
   void on_awake() override;
   void on_update(float dt) override;
-
+  
   void add_player(PlayerObject& player);
   void remove_player(PlayerObject &player);
-
+  
   void respawn_player(const PlayerObject &player, Vector3 pos);
-
+  
   bool is_player_registered(const PlayerObject& player) const;
-
+  
+  void round_end();
   void on_round_end(const round_end_callback_t &callback);
 
   [[nodiscard]] std::vector<Vector3> spawn_positions() const;

--- a/src/character/player_outofbounds_behavior.cpp
+++ b/src/character/player_outofbounds_behavior.cpp
@@ -17,7 +17,10 @@ void PlayerOutOfBoundsBehavior::on_update(float delta_time) {
   const auto& components = game_object().get_components<BehaviorScript>();
   for (auto behavior : components) {
     if (PlayerController* player_controller = dynamic_cast<PlayerController*>(&behavior.get().behavior())) {
-      player_controller->damage(player_controller->health());
+      if (player_controller->is_alive()) {
+        player_controller->damage(player_controller->health());
+      }
+
       break;
     }
   }

--- a/src/round/roundcontroller.cpp
+++ b/src/round/roundcontroller.cpp
@@ -63,14 +63,15 @@ void RoundController::on_player_death(PlayerObject &player) {
     controller->lives(controller->lives() - 1);
 
     spawn_dead_player(player);
+    check_round_end_conditions();
 
     if (controller->lives() < 1) {
-      player.mark_for_deletion();
+      player.set_inactive();
       return;
     }
 
     auto& multiplayer_service = Engine::instance().services->get_service<MultiplayerService>().get();
-    if (multiplayer_service.get_peer_type() == PeerType::CLIENT) return;
+    if (multiplayer_service.get_peer_type() != PeerType::CLIENT) return;
 
     generate_new_spawn_position();
     if (multiplayer_service.get_peer_type() == PeerType::HOST) {
@@ -109,10 +110,56 @@ void RoundController::remove_player(PlayerObject &player) {
   realign_player_info_positions();
 }
 
-void RoundController::round_end() const {
+void RoundController::check_round_end_conditions() {
+  int alive_count = 0;
+  PlayerObject* last_alive_player = nullptr;
+
+  for (const auto &player_ref : players) {
+    auto &player = player_ref.get();
+    auto controller_opt = player.get_script<BehaviorScript, PlayerController>();
+
+    if (!controller_opt.has_value()) continue;
+
+    auto controller = &controller_opt->get();
+    if (controller->lives() > 0) {
+      alive_count++;
+      last_alive_player = &player;
+    }
+  }
+
+  if (alive_count == 1 && last_alive_player != nullptr) {
+    winner_player_ = *last_alive_player;
+    round_end();
+  } 
+  else if (alive_count == 0) {
+    winner_player_ = std::nullopt;
+    round_end();
+  }
+}
+
+void RoundController::round_end() {
+  round_active_ = false;
+  
   for (auto &callback : round_end_callbacks) {
     callback();
   }
+  
+  auto& multiplayer_service = Engine::instance().services->get_service<MultiplayerService>().get();
+  if (multiplayer_service.get_peer_type() != PeerType::HOST) return;
+  
+  if (!winner_player_) return;
+  std::string winner_uuid;
+
+  if (const auto& network_id = winner_player_->get().get_component<NetworkIdentity>(); network_id.has_value()) {
+    winner_uuid = network_id.value().get().uuid();
+  } 
+
+  MsgRoundEnd body{};
+  std::strncpy(body.winner_uuid, winner_uuid.c_str(), sizeof(body.winner_uuid) - 1);
+  body.draw = winner_uuid.empty();
+
+  Message msg = serialize_message(body, CustomMessageTypes::ROUND_END);
+  multiplayer_service.send(msg);
 }
 
 void RoundController::on_round_end(const round_end_callback_t &callback) {

--- a/src/round/roundcontroller.cpp
+++ b/src/round/roundcontroller.cpp
@@ -71,7 +71,7 @@ void RoundController::on_player_death(PlayerObject &player) {
     }
 
     auto& multiplayer_service = Engine::instance().services->get_service<MultiplayerService>().get();
-    if (multiplayer_service.get_peer_type() != PeerType::CLIENT) return;
+    if (multiplayer_service.get_peer_type() == PeerType::CLIENT) return;
 
     generate_new_spawn_position();
     if (multiplayer_service.get_peer_type() == PeerType::HOST) {
@@ -152,7 +152,7 @@ void RoundController::round_end() {
 
   if (const auto& network_id = winner_player_->get().get_component<NetworkIdentity>(); network_id.has_value()) {
     winner_uuid = network_id.value().get().uuid();
-  } 
+  }
 
   MsgRoundEnd body{};
   std::strncpy(body.winner_uuid, winner_uuid.c_str(), sizeof(body.winner_uuid) - 1);

--- a/src/scenes/swamp_autum.cpp
+++ b/src/scenes/swamp_autum.cpp
@@ -90,8 +90,15 @@ RoundController& SwampAutumScene::add_multiplayer_round_controller() {
     };
 
     GameObject& wrapper = scene().add_game_object("RoundControllerWrapper");
+    
     auto& comp = wrapper.add_component<BehaviorScript>(std::make_unique<RoundController>(respawn_positions));
-    return *dynamic_cast<RoundController*>(&comp.behavior());
+    auto& controller = *dynamic_cast<RoundController*>(&comp.behavior());
+    controller.on_round_end([this]() {
+        auto& scene_service = Engine::instance().services->get_service<SceneService>().get();
+        scene_service.load_scene("MainMenuScene");
+    });
+
+    return controller;
 }
 
 MultiplayerController& SwampAutumScene::add_multiplayer_controller() {
@@ -332,6 +339,15 @@ void SwampAutumScene::register_client_handlers(MultiplayerService& multiplayer_s
         handle_player_drop_weapon(data);
     });
 
+    multiplayer_service.register_handler(CustomMessageTypes::USER_RESPAWN, [this, &controller](const Message& message) {
+        MsgUserRespawn data{};
+        std::memcpy(&data, message.payload.data(), sizeof(data));
+
+        if (auto player_opt = get_network_player_object(data.uuid); player_opt.has_value()) {
+            controller.respawn_player(player_opt.value().get(), {data.x, data.y, data.z});
+        }
+    });
+
     multiplayer_service.register_handler(CustomMessageTypes::DROP_SPAWN, [this, &prefab_service, &scene](const Message& message) {
         MsgDropSpawn data{};
         std::memcpy(&data, message.payload.data(), sizeof(data));
@@ -353,12 +369,21 @@ void SwampAutumScene::register_client_handlers(MultiplayerService& multiplayer_s
         }
     });
 
-    multiplayer_service.register_handler(CustomMessageTypes::USER_RESPAWN, [this, &controller](const Message& message) {
-        MsgUserRespawn data{};
+    multiplayer_service.register_handler(CustomMessageTypes::ROUND_END, [this, &controller, &scene](const Message& message) {
+        MsgRoundEnd data{};
         std::memcpy(&data, message.payload.data(), sizeof(data));
 
-        if (auto player_opt = get_network_player_object(data.uuid); player_opt.has_value()) {
-            controller.respawn_player(player_opt.value().get(), {data.x, data.y, data.z});
+        if (auto player_opt = get_network_player_object(data.winner_uuid); player_opt.has_value()) {
+            /// TODO: Show winner UI
+        }
+
+        for (auto& object_ref : scene.game_objects()) {
+            auto& object = object_ref.get();
+            
+            auto round_controller_opt = object.get_script<BehaviorScript, RoundController>();
+            if (round_controller_opt.has_value()) {
+                round_controller_opt->get().round_end();
+            }
         }
     });
 }


### PR DESCRIPTION
This PR adds the network message when a round is ended. The HOST always decides when this is, which is based on the players that are alive.

Currently it just sends all back to the main menu. There is a `TODO` there and in another PR a GUI will be created, for now this suffices.