### PR TITLE
fix (interactables): despawning in dropper

### DIFF
--- a/include/game/behaviors/interactable/weapon_axe.h
+++ b/include/game/behaviors/interactable/weapon_axe.h
@@ -5,12 +5,13 @@
 
 class WeaponAxeInteractableBehavior : public Behavior {
 public:
-    WeaponAxeInteractableBehavior() = default;
+    WeaponAxeInteractableBehavior(bool is_dropped = false);
     ~WeaponAxeInteractableBehavior() override = default;
 
     void on_start() override;
     void on_update(float dt) override;
 private:
+    bool is_dropped_{false};
     float pickup_delay_{0.2f};
     float destroy_delay_{15.0f};
     float time_since_spawn_{0.0f};

--- a/include/game/behaviors/interactable/weapon_bat.h
+++ b/include/game/behaviors/interactable/weapon_bat.h
@@ -4,12 +4,13 @@
 
 class WeaponBatInteractableBehavior : public Behavior {
 public:
-    WeaponBatInteractableBehavior() = default;
+    WeaponBatInteractableBehavior(bool is_dropped = false);
     ~WeaponBatInteractableBehavior() override = default;
 
     void on_start() override;
     void on_update(float dt) override;
 private:
+    bool is_dropped_{false};
     float pickup_delay_{0.5f};
     float destroy_delay_{15.0f};
     float time_since_spawn_{0.0f};

--- a/include/game/behaviors/interactable/weapon_sword.h
+++ b/include/game/behaviors/interactable/weapon_sword.h
@@ -4,12 +4,13 @@
 
 class WeaponSwordInteractableBehavior : public Behavior {
 public:
-    WeaponSwordInteractableBehavior() = default;
+    WeaponSwordInteractableBehavior(bool is_dropped = false);
     ~WeaponSwordInteractableBehavior() override = default;
 
     void on_start() override;
     void on_update(float dt) override;
 private:
+    bool is_dropped_{false};
     float pickup_delay_{0.5f};
     float destroy_delay_{15.0f};
     float time_since_spawn_{0.0f};

--- a/src/behaviors/interactables/weapon_axe.cpp
+++ b/src/behaviors/interactables/weapon_axe.cpp
@@ -12,6 +12,9 @@
 #include <engine/public/components/network_identity.h>
 #include <engine/public/gameObject.h>
 
+WeaponAxeInteractableBehavior::WeaponAxeInteractableBehavior(bool is_dropped)
+    : is_dropped_{is_dropped} {}
+
 void WeaponAxeInteractableBehavior::on_start() {
     auto collider_opt = get_component<BoxCollider2D>();
     if (!collider_opt.has_value()) {
@@ -71,7 +74,7 @@ void WeaponAxeInteractableBehavior::on_update(float dt) {
         rb.velocity({0.0f, rb.velocity().y, 0.0f});
     }
 
-    if (time_since_spawn_ > destroy_delay_) {
+    if (time_since_spawn_ > destroy_delay_ && is_dropped_) {
         this->game_object().mark_for_deletion();
         return;
     }

--- a/src/behaviors/interactables/weapon_bat.cpp
+++ b/src/behaviors/interactables/weapon_bat.cpp
@@ -9,6 +9,9 @@
 #include <engine/public/components/behaviorscript.h>
 #include <engine/public/gameObject.h>
 
+WeaponBatInteractableBehavior::WeaponBatInteractableBehavior(bool is_dropped)
+    : is_dropped_{is_dropped} {}
+
 void WeaponBatInteractableBehavior::on_start() {
     auto collider_opt = get_component<BoxCollider2D>();
     if (!collider_opt.has_value()) {
@@ -66,7 +69,7 @@ void WeaponBatInteractableBehavior::on_update(float dt) {
         rb.velocity({0.0f, rb.velocity().y, 0.0f});
     }
 
-    if (time_since_spawn_ > destroy_delay_) {
+    if (time_since_spawn_ > destroy_delay_ && is_dropped_) {
         this->game_object().mark_for_deletion();
         return;
     }

--- a/src/behaviors/interactables/weapon_sword.cpp
+++ b/src/behaviors/interactables/weapon_sword.cpp
@@ -9,6 +9,9 @@
 #include <engine/public/components/behaviorscript.h>
 #include <engine/public/gameObject.h>
 
+WeaponSwordInteractableBehavior::WeaponSwordInteractableBehavior(bool is_dropped)
+    : is_dropped_{is_dropped} {}
+
 void WeaponSwordInteractableBehavior::on_start() {
     auto collider_opt = get_component<BoxCollider2D>();
     if (!collider_opt.has_value()) {
@@ -17,7 +20,7 @@ void WeaponSwordInteractableBehavior::on_start() {
 
     collider_opt->get().add_on_trigger_enter([this](Collider2D& self, Collider2D& other) {
         if (time_since_spawn_ < pickup_delay_) return;
-
+        
         auto behavior_opt = self.parent()->get().get_component<BehaviorScript>();
         if (!behavior_opt.has_value()) return;
 
@@ -66,7 +69,7 @@ void WeaponSwordInteractableBehavior::on_update(float dt) {
         rb.velocity({0.0f, rb.velocity().y, 0.0f});
     }
 
-    if (time_since_spawn_ > destroy_delay_) {
+    if (time_since_spawn_ > destroy_delay_ && is_dropped_) {
         this->game_object().mark_for_deletion();
         return;
     }

--- a/src/prefabs/interactable/weapon_axe.cpp
+++ b/src/prefabs/interactable/weapon_axe.cpp
@@ -28,7 +28,7 @@ WeaponAxePrefab::WeaponAxePrefab(Scene& scene, bool is_dropped, Vector3 position
     }
 
     this->add_component<BoxCollider2D>(0.6, 0.2, 32, 32, Point{0, 0}, !is_dropped, !is_dropped);
-    this->add_component<BehaviorScript>(std::make_unique<WeaponAxeInteractableBehavior>());
+    this->add_component<BehaviorScript>(std::make_unique<WeaponAxeInteractableBehavior>(is_dropped));
 
     this->layer(Layers::Foreground + 2);
 }

--- a/src/prefabs/interactable/weapon_bat.cpp
+++ b/src/prefabs/interactable/weapon_bat.cpp
@@ -29,7 +29,7 @@ WeaponBatPrefab::WeaponBatPrefab(Scene& scene, bool is_dropped, Vector3 position
     }
 
     this->add_component<BoxCollider2D>(0, 0, 24, 48, Point{0, 0}, !is_dropped, !is_dropped);
-    this->add_component<BehaviorScript>(std::make_unique<WeaponBatInteractableBehavior>());
+    this->add_component<BehaviorScript>(std::make_unique<WeaponBatInteractableBehavior>(is_dropped));
 
     this->layer(Layers::Foreground + 2);
 }

--- a/src/prefabs/interactable/weapon_sword.cpp
+++ b/src/prefabs/interactable/weapon_sword.cpp
@@ -28,7 +28,7 @@ WeaponSwordPrefab::WeaponSwordPrefab(Scene& scene, bool is_dropped, Vector3 posi
     }
 
     this->add_component<BoxCollider2D>(0, 0, 32, 32, Point{0, 0}, !is_dropped, !is_dropped);
-    this->add_component<BehaviorScript>(std::make_unique<WeaponSwordInteractableBehavior>());
+    this->add_component<BehaviorScript>(std::make_unique<WeaponSwordInteractableBehavior>(is_dropped));
 
     layer(Layers::Foreground + 2);
 }


### PR DESCRIPTION
This PR fixes the bug where interactables would despawn in dropper due to them not knowing if dropped.