### PR TITLE
feat (lobby): add lobby and player colors

### DIFF
--- a/include/game/behaviors/multiplayer/multiplayer_controller.h
+++ b/include/game/behaviors/multiplayer/multiplayer_controller.h
@@ -17,6 +17,7 @@ enum class UserColor : uint16_t {
 
 struct User {
   std::string uuid;
+  std::string username;
   UserColor color;
 };
 
@@ -26,7 +27,7 @@ private:
 
   std::vector<connection_state_change_callback_t> connection_state_change_callbacks;
 
-  std::map<UserColor, std::string> users_;
+  std::map<UserColor, User> users_;
 
 public:
     void on_update(float dt) override;
@@ -34,7 +35,8 @@ public:
     void on_connection_state_change(connection_state_change_callback_t callback);
 
     void register_user(std::string uuid);
+    void register_user(std::string uuid, std::string username, UserColor color);
     void unregister_user(std::string uuid);
 
-    std::map<UserColor, std::string> users();
+    std::map<UserColor, User> users();
 };

--- a/include/game/behaviors/multiplayer/multiplayer_controller.h
+++ b/include/game/behaviors/multiplayer/multiplayer_controller.h
@@ -3,7 +3,22 @@
 #include <engine/network/multiplayer_service.h>
 #include <engine/public/behavior.h>
 
+#include <map>
+#include <cstdint>
+
 using connection_state_change_callback_t = std::function<void(ConnectionState, ConnectionState)>;
+
+enum class UserColor : uint16_t {
+  YELLOW = 0,
+  BLUE,
+  RED,
+  GREEN
+};
+
+struct User {
+  std::string uuid;
+  UserColor color;
+};
 
 class MultiplayerController : public Behavior {
 private:
@@ -11,8 +26,15 @@ private:
 
   std::vector<connection_state_change_callback_t> connection_state_change_callbacks;
 
+  std::map<UserColor, std::string> users_;
+
 public:
     void on_update(float dt) override;
 
     void on_connection_state_change(connection_state_change_callback_t callback);
+
+    void register_user(std::string uuid);
+    void unregister_user(std::string uuid);
+
+    std::map<UserColor, std::string> users();
 };

--- a/include/game/character/playerConstants.h
+++ b/include/game/character/playerConstants.h
@@ -1,16 +1,92 @@
 #pragma once
+#include <string_view>
+
+enum class PlayerColor : uint16_t {
+    DEFAULT = 0,
+    RED,
+    BLUE,
+    GREEN
+};
+
+struct PlayerAnimationConstants {
+    std::string_view walking_animation;
+    std::string_view idle_animation;
+    std::string_view jumping_animation;
+    std::string_view crouching_animation;
+    std::string_view death_animation;
+    std::string_view hit_animation;
+    
+    std::string_view idle_texture;
+    std::string_view crouching_texture;
+    std::string_view jumping_texture;
+    std::string_view death_texture;
+    std::string_view hit_texture;
+    std::string_view head_texture;
+};
 
 namespace PlayerConstants {
-    constexpr auto WALKING_ANIMATION = "capybara_default_walk_anim";
-    constexpr auto IDLE_ANIMATION = "capybara_default_idle_anim";
-    constexpr auto JUMPING_ANIMATION = "capybara_default_jump_anim";
-    constexpr auto CROUCHING_ANIMATION = "capybara_default_duck_anim";
-    constexpr auto DEATH_ANIMATION = "capybara_default_death_anim";
-    constexpr auto HIT_ANIMATION = "capybara_default_hit_anim";
-
-    constexpr auto IDLE_TEXTURE = "capybara_default_idle";
-    constexpr auto CROUCHING_TEXTURE = "capybara_default_duck";
-    constexpr auto JUMPING_TEXTURE = "capybara_default_jump";
-    constexpr auto DEATH_TEXTURE = "capybara_default_death";
-    constexpr auto HIT_TEXTURE = "capybara_default_hit";
+    constexpr PlayerAnimationConstants get_constants(PlayerColor color) {
+        switch (color) {
+            case PlayerColor::RED:
+                return {
+                    "capybara_red_walk_anim",
+                    "capybara_red_idle_anim",
+                    "capybara_red_jump_anim",
+                    "capybara_red_duck_anim",
+                    "capybara_red_death_anim",
+                    "capybara_red_hit_anim",
+                    "capybara_red_idle",
+                    "capybara_red_duck",
+                    "capybara_red_jump",
+                    "capybara_red_death",
+                    "capybara_red_hit",
+                    "capybara_red_head"
+                };
+            case PlayerColor::BLUE:
+                return {
+                    "capybara_blue_walk_anim",
+                    "capybara_blue_idle_anim",
+                    "capybara_blue_jump_anim",
+                    "capybara_blue_duck_anim",
+                    "capybara_blue_death_anim",
+                    "capybara_blue_hit_anim",
+                    "capybara_blue_idle",
+                    "capybara_blue_duck",
+                    "capybara_blue_jump",
+                    "capybara_blue_death",
+                    "capybara_blue_hit",
+                    "capybara_blue_head"
+                };
+            case PlayerColor::GREEN:
+                return {
+                    "capybara_green_walk_anim",
+                    "capybara_green_idle_anim",
+                    "capybara_green_jump_anim",
+                    "capybara_green_duck_anim",
+                    "capybara_green_death_anim",
+                    "capybara_green_hit_anim",
+                    "capybara_green_idle",
+                    "capybara_green_duck",
+                    "capybara_green_jump",
+                    "capybara_green_death",
+                    "capybara_green_hit",
+                    "capybara_green_head"
+                };
+            default: // PlayerColor::DEFAULT
+                return {
+                    "capybara_default_walk_anim",
+                    "capybara_default_idle_anim",
+                    "capybara_default_jump_anim",
+                    "capybara_default_duck_anim",
+                    "capybara_default_death_anim",
+                    "capybara_default_hit_anim",
+                    "capybara_default_idle",
+                    "capybara_default_duck",
+                    "capybara_default_jump",
+                    "capybara_default_death",
+                    "capybara_default_hit",
+                    "capybara_default_head"
+                };
+        }
+    }
 }

--- a/include/game/character/player_object.h
+++ b/include/game/character/player_object.h
@@ -4,6 +4,7 @@
 #include "engine/public/util/point.h"
 #include "engine/public/components/behaviorscript.h"
 #include "game/character/player_movement_behavior.h"
+#include "game/character/playerConstants.h"
 
 class PlayerObject final : public GameObject {
 public:
@@ -19,6 +20,13 @@ public:
   void user_name(std::string user_name);
   const std::string& user_name() const;
 
+  void user_color(PlayerColor user_color);
+  const PlayerColor user_color() const;
+
+  const PlayerAnimationConstants& constants() const;
+
 private:
   std::string user_name_;
+  PlayerColor color_;
+  PlayerAnimationConstants constants_;
 };

--- a/include/game/network/message_types.h
+++ b/include/game/network/message_types.h
@@ -13,6 +13,7 @@ enum class CustomMessageTypes : uint16_t {
     DROP_SPAWN,
 
     LOBBY_DATA,
+    ROUND_START,
     ROUND_END
 };
 
@@ -60,6 +61,10 @@ struct MsgUserRespawn {
 
 struct MsgUserDropWeapon {
     char uuid[37];
+};
+
+struct MsgRoundStart {
+    // Don't need any data to send
 };
 
 struct MsgRoundEnd {

--- a/include/game/network/message_types.h
+++ b/include/game/network/message_types.h
@@ -12,6 +12,7 @@ enum class CustomMessageTypes : uint16_t {
     USER_DROP_WEAPON,
     DROP_SPAWN,
 
+    LOBBY_DATA,
     ROUND_END
 };
 
@@ -21,6 +22,17 @@ struct MsgUserJoin {
 
 struct MsgUserLeave {
     char uuid[37];
+};
+
+struct LobbyUserData {
+    char uuid[37];
+    uint16_t color;
+    char name[255];
+};
+
+struct MsgLobbyData {
+    uint32_t user_count;
+    LobbyUserData users[4];  // Max 4 players
 };
 
 struct MsgUserMove {

--- a/include/game/pause_menu_ui.h
+++ b/include/game/pause_menu_ui.h
@@ -92,19 +92,35 @@ private:
             "button_large_red"
         );
         btn.parent(*this);
-        btn.add_on_press([this](UIButton&)
+        btn.add_on_press([this, &scene](UIButton&)
         {
             auto& multiplayer_service = Engine::instance().services->get_service<MultiplayerService>().get();
             if (multiplayer_service.get_connection_state() == ConnectionState::CONNECTED) {
-                // TODO: CLEAN LEAVE, First send leave message and clean stuff. Then disconnect.
-                
-                if (multiplayer_service.get_peer_type() == PeerType::CLIENT) {
-                    MsgUserLeave data{};
-                    std::memcpy(&data, multiplayer_service.get_uuid().c_str(), sizeof(data));
+                MsgUserLeave data{};
+                std::memcpy(&data, multiplayer_service.get_uuid().c_str(), sizeof(data));
 
-                    Message msg = serialize_message(data, CustomMessageTypes::USER_LEAVE);
-                    multiplayer_service.send(msg);
+                Message msg = serialize_message(data, CustomMessageTypes::USER_LEAVE);
+                multiplayer_service.send(msg);
+
+                std::optional<std::reference_wrapper<GameObject>> multiplayer_controller_opt;
+                for (auto& obj : scene.game_objects()) {
+                    if (obj.get().name() == "MultiplayerController") {
+                        multiplayer_controller_opt = obj;
+                        break;
+                    }
                 }
+
+                if (multiplayer_controller_opt.has_value()) {
+                    multiplayer_controller_opt.value().get().mark_dont_destroy_on_load(false);
+                }
+
+                multiplayer_service.unregister_handler(CustomMessageTypes::USER_JOIN);
+                multiplayer_service.unregister_handler(CustomMessageTypes::USER_LEAVE);
+                if (multiplayer_service.get_peer_type() == PeerType::CLIENT) {
+                    multiplayer_service.unregister_handler(CustomMessageTypes::ROUND_START);
+                    multiplayer_service.unregister_handler(CustomMessageTypes::LOBBY_DATA);
+                }
+
                 multiplayer_service.disconnect();
             } 
             else if (multiplayer_service.get_connection_state() != ConnectionState::NONE

--- a/include/game/pause_menu_ui.h
+++ b/include/game/pause_menu_ui.h
@@ -94,7 +94,26 @@ private:
         btn.parent(*this);
         btn.add_on_press([this](UIButton&)
         {
+            auto& multiplayer_service = Engine::instance().services->get_service<MultiplayerService>().get();
+            if (multiplayer_service.get_connection_state() == ConnectionState::CONNECTED) {
+                // TODO: CLEAN LEAVE, First send leave message and clean stuff. Then disconnect.
+                
+                if (multiplayer_service.get_peer_type() == PeerType::CLIENT) {
+                    MsgUserLeave data{};
+                    std::memcpy(&data, multiplayer_service.get_uuid().c_str(), sizeof(data));
+
+                    Message msg = serialize_message(data, CustomMessageTypes::USER_LEAVE);
+                    multiplayer_service.send(msg);
+                }
+                multiplayer_service.disconnect();
+            } 
+            else if (multiplayer_service.get_connection_state() != ConnectionState::NONE
+                    && multiplayer_service.get_connection_state() != ConnectionState::DISCONNECTED) {
+                return;
+            }
+
             quit_press_callback_();
+
             auto& scene_service = Engine::instance().services->get_service<SceneService>().get();
             scene_service.load_scene("MainMenuScene");
         });

--- a/include/game/pause_menu_ui.h
+++ b/include/game/pause_menu_ui.h
@@ -95,7 +95,9 @@ private:
         btn.add_on_press([this, &scene](UIButton&)
         {
             auto& multiplayer_service = Engine::instance().services->get_service<MultiplayerService>().get();
-            if (multiplayer_service.get_connection_state() == ConnectionState::CONNECTED) {
+            if (multiplayer_service.get_connection_state() == ConnectionState::CONNECTED
+                || multiplayer_service.get_connection_state() == ConnectionState::CONNECTING
+                || multiplayer_service.get_connection_state() == ConnectionState::DISCONNECTING) {
                 MsgUserLeave data{};
                 std::memcpy(&data, multiplayer_service.get_uuid().c_str(), sizeof(data));
 

--- a/include/game/prefabs/character/dying_capybara_object.h
+++ b/include/game/prefabs/character/dying_capybara_object.h
@@ -2,10 +2,11 @@
 
 #include <engine/public/gameObject.h>
 #include <engine/public/util/vector3.h>
+#include <game/character/playerConstants.h>
 
 class DyingCapybaraObject final : public GameObject {
 public:
-  explicit DyingCapybaraObject(Scene& scene, Vector3 position, float disappear_time = 2.0f);
+  explicit DyingCapybaraObject(Scene& scene, Vector3 position, float disappear_time = 2.0f, PlayerColor color = PlayerColor::DEFAULT);
   ~DyingCapybaraObject() override = default;
 
 private:

--- a/include/game/scenes/lobby.h
+++ b/include/game/scenes/lobby.h
@@ -2,6 +2,7 @@
 
 #include <game/character/player_object.h>
 #include <game/scenes/level.h>
+#include <game/behaviors/multiplayer/multiplayer_controller.h>
 
 class LobbyScene : public Level {
 public:
@@ -12,6 +13,20 @@ public:
     virtual void load(Scene& scene) override;
 
 private:
+    GameObject& multiplayer_controller_;
+    std::vector<GameObject*> player_frames_;
+
+    GameObject& create_multiplayer_controller();
+
+    void register_host_handlers(MultiplayerService& multiplayer_service);
+    void register_client_handlers(MultiplayerService& multiplayer_service);
+
+    void update_player_displays(MultiplayerService& multiplayer_service);
+
+    void create_ip_text();
+    void create_player_displays(MultiplayerService& multiplayer_service);
+    void create_start_button();
+
     UIButton& create_button(Scene& scene, const std::string& label, float position_x, float position_y, const std::string& texture_id);
     UIText& player_name(Scene &scene, const std::string& username, float frame_width, float font_size);
 };

--- a/include/game/scenes/lobby.h
+++ b/include/game/scenes/lobby.h
@@ -14,7 +14,7 @@ public:
 
 private:
     GameObject& multiplayer_controller_;
-    std::vector<GameObject*> player_frames_;
+    std::vector<std::reference_wrapper<GameObject>> player_frames_;
 
     GameObject& create_multiplayer_controller();
 

--- a/include/game/scenes/lobby.h
+++ b/include/game/scenes/lobby.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <game/character/player_object.h>
+#include <game/scenes/level.h>
+
+class LobbyScene : public Level {
+public:
+    LobbyScene();
+    virtual ~LobbyScene() = default;
+
+    virtual void setup(Scene& scene) override;
+    virtual void load(Scene& scene) override;
+
+private:
+    UIButton& create_button(Scene& scene, const std::string& label, float position_x, float position_y, const std::string& texture_id);
+    UIText& player_name(Scene &scene, const std::string& username, float frame_width, float font_size);
+};

--- a/include/game/scenes/swamp_autum.h
+++ b/include/game/scenes/swamp_autum.h
@@ -30,7 +30,7 @@ private:
     PlayerObject& create_player_object(const std::string& name);
     GameObject& create_interactable_dropper(const std::string& name);
     RoundController& add_multiplayer_round_controller();
-    MultiplayerController& add_multiplayer_controller();
+    // MultiplayerController& add_multiplayer_controller();
 
     void handle_player_movement_update(const MsgUserMove& data);
     void handle_player_attack(const MsgUserAttack& data);

--- a/include/game/scenes/swamp_autum.h
+++ b/include/game/scenes/swamp_autum.h
@@ -30,7 +30,6 @@ private:
     PlayerObject& create_player_object(const std::string& name);
     GameObject& create_interactable_dropper(const std::string& name);
     RoundController& add_multiplayer_round_controller();
-    // MultiplayerController& add_multiplayer_controller();
 
     void handle_player_movement_update(const MsgUserMove& data);
     void handle_player_attack(const MsgUserAttack& data);

--- a/src/behaviors/multiplayer/multiplayer_controller.cpp
+++ b/src/behaviors/multiplayer/multiplayer_controller.cpp
@@ -31,3 +31,42 @@ void MultiplayerController::on_update(float dt) {
 void MultiplayerController::on_connection_state_change(connection_state_change_callback_t callback) {
     connection_state_change_callbacks.push_back(callback);
 }
+
+void MultiplayerController::register_user(std::string uuid) {
+    for (uint16_t i = 0; i <= static_cast<uint16_t>(UserColor::GREEN); ++i) {
+        auto color = static_cast<UserColor>(i);
+
+        if (users_.find(color) == users_.end()) {
+            users_.emplace(color, uuid);
+            return;
+        }
+    }
+}
+
+void MultiplayerController::unregister_user(std::string uuid) {
+    auto it = std::find_if(users_.begin(), users_.end(), [&](const auto& pair) {
+            return pair.second == uuid;
+        });
+
+    if (it == users_.end()) return;
+
+    auto shift_it = std::next(it);
+    users_.erase(it);
+
+    while (shift_it != users_.end()) {
+        auto current = shift_it++;
+        UserColor old_color = current->first;
+        const std::string value = current->second;
+
+        users_.erase(current);
+
+        UserColor new_color = static_cast<UserColor>(static_cast<uint16_t>(old_color) - 1);
+
+        users_.emplace(new_color, value);
+    }
+}
+
+
+std::map<UserColor, std::string> MultiplayerController::users() {
+    return users_;
+}

--- a/src/behaviors/multiplayer/multiplayer_controller.cpp
+++ b/src/behaviors/multiplayer/multiplayer_controller.cpp
@@ -37,15 +37,21 @@ void MultiplayerController::register_user(std::string uuid) {
         auto color = static_cast<UserColor>(i);
 
         if (users_.find(color) == users_.end()) {
-            users_.emplace(color, uuid);
+            User new_user = {uuid, "", color};
+            users_.emplace(color, new_user);
             return;
         }
     }
 }
 
+void MultiplayerController::register_user(std::string uuid, std::string username, UserColor color) {
+    User new_user = {uuid, "PLACEHOLDER", color};
+    users_.emplace(color, new_user);
+}
+
 void MultiplayerController::unregister_user(std::string uuid) {
     auto it = std::find_if(users_.begin(), users_.end(), [&](const auto& pair) {
-            return pair.second == uuid;
+            return pair.second.uuid == uuid;
         });
 
     if (it == users_.end()) return;
@@ -56,7 +62,7 @@ void MultiplayerController::unregister_user(std::string uuid) {
     while (shift_it != users_.end()) {
         auto current = shift_it++;
         UserColor old_color = current->first;
-        const std::string value = current->second;
+        const User value = current->second;
 
         users_.erase(current);
 
@@ -67,6 +73,6 @@ void MultiplayerController::unregister_user(std::string uuid) {
 }
 
 
-std::map<UserColor, std::string> MultiplayerController::users() {
+std::map<UserColor, User> MultiplayerController::users() {
     return users_;
 }

--- a/src/behaviors/multiplayer/multiplayer_controller.cpp
+++ b/src/behaviors/multiplayer/multiplayer_controller.cpp
@@ -62,11 +62,12 @@ void MultiplayerController::unregister_user(std::string uuid) {
     while (shift_it != users_.end()) {
         auto current = shift_it++;
         UserColor old_color = current->first;
-        const User value = current->second;
+        User value = current->second;
 
         users_.erase(current);
 
         UserColor new_color = static_cast<UserColor>(static_cast<uint16_t>(old_color) - 1);
+        value.color = new_color;
 
         users_.emplace(new_color, value);
     }

--- a/src/behaviors/ui/end_round_continue_behavior.cpp
+++ b/src/behaviors/ui/end_round_continue_behavior.cpp
@@ -14,6 +14,6 @@ void EndRoundContinueBehavior::on_update(float dt) {
         game_object().mark_for_deletion();
 
         auto& scene_service = Engine::instance().services->get_service<SceneService>().get();
-        scene_service.load_scene("MainMenuScene");
+        scene_service.load_scene("Level_LobbyScene");
     }
 }

--- a/src/character/gui/player_info_component.cpp
+++ b/src/character/gui/player_info_component.cpp
@@ -47,9 +47,8 @@ namespace PlayerInfoComponent {
 
     GameObject &left_col(Scene &scene, const PlayerObject &player) {
         GameObject &left_col = scene.add_game_object("");
-
         auto &player_background = scene.add_game_object<UIImage>(scene, "button_small_black_empty", left_col_width, left_col_height, Point{}, Point{});
-        auto &player_skin_image = scene.add_game_object<UIImage>(scene, "capybara_default_head", left_col_width, left_col_height, Point{}, Point{});
+        auto &player_skin_image = scene.add_game_object<UIImage>(scene, player.constants().head_texture.data(), left_col_width, left_col_height, Point{}, Point{});
         auto &player_border = scene.add_game_object<UIImage>(scene, "button_small_hollow", left_col_width, left_col_height, Point{}, Point{});
 
         left_col.add_child(player_background);

--- a/src/character/player_controller.cpp
+++ b/src/character/player_controller.cpp
@@ -1,3 +1,4 @@
+#include <game/character/player_object.h>
 #include <game/character/player_controller.h>
 #include <game/character/playerConstants.h>
 #include <game/prefabs/character/dying_capybara_object.h>
@@ -117,7 +118,7 @@ void PlayerController::hit(int damage) {
   
   if (animator) {
     animator->get().is_non_interruptible(true);
-    animator->get().play(PlayerConstants::HIT_ANIMATION, false);
+    animator->get().play(dynamic_cast<PlayerObject*>(&game_object())->constants().hit_animation.data(), false);
   }
 
   this->damage(damage);

--- a/src/character/player_movement_behavior.cpp
+++ b/src/character/player_movement_behavior.cpp
@@ -3,6 +3,7 @@
 #include <engine/audio/audio_service.h>
 
 #include <game/character/playerConstants.h>
+#include <game/character/player_object.h>
 #include <game/network/message_types.h>
 
 #include <engine/core/engine.h>
@@ -218,6 +219,7 @@ void PlayerMovementBehavior::apply_physics() {
 void PlayerMovementBehavior::apply_animation() {
   auto& animator = animator_opt_->get();
   auto& sprite   = sprite_opt_->get();
+  auto& constants = dynamic_cast<PlayerObject*>(&game_object())->constants();
 
   if (move_left_)  sprite.flip_x(true);
   if (move_right_) sprite.flip_x(false);
@@ -225,22 +227,22 @@ void PlayerMovementBehavior::apply_animation() {
   if (animator.is_non_interruptible()) return;
 
   if (crouch_) {
-    sprite.texture(PlayerConstants::CROUCHING_TEXTURE);
+    sprite.texture(constants.crouching_texture.data());
     return;
   }
 
   if ((jump_ || is_double_jumping_) && !is_grounded_) {
-    sprite.texture(PlayerConstants::JUMPING_TEXTURE);
+    sprite.texture(constants.jumping_texture.data());
     return;
   }
 
   if (is_walking_ && is_grounded_ && !animator.is_playing()) {
-    animator.play(PlayerConstants::WALKING_ANIMATION, true);
+    animator.play(constants.walking_animation.data(), true);
   }
 
   if (!crouch_ && !is_walking_ && is_grounded_) {
     animator.pause();
-    sprite.texture(PlayerConstants::IDLE_TEXTURE);
+    sprite.texture(constants.idle_texture.data());
   }
 }
 

--- a/src/character/player_object.cpp
+++ b/src/character/player_object.cpp
@@ -19,7 +19,7 @@
 #include <engine/network/multiplayer_service.h>
 
 PlayerObject::PlayerObject(Scene &scene, const Vector3 initial_pos, bool is_local_player)
-    : GameObject(scene), user_name_{"PLACEHOLDER"} {
+    : GameObject(scene), user_name_{"PLACEHOLDER"}, color_{PlayerColor::DEFAULT}, constants_{PlayerConstants::get_constants(PlayerColor::DEFAULT)} {
   this->name("PlayerObject");
   this->tag("Player");
   this->transform().position(initial_pos);
@@ -93,10 +93,13 @@ bool PlayerObject::is_local(GameObject& obj) {
   return true;
 }
 
-void PlayerObject::user_name(std::string user_name) {
-  user_name_ = user_name;
-}
+void PlayerObject::user_name(std::string user_name) { user_name_ = user_name; }
+const std::string& PlayerObject::user_name() const { return user_name_; }
 
-const std::string& PlayerObject::user_name() const {
-  return user_name_;
+void PlayerObject::user_color(PlayerColor user_color) {
+  color_ = user_color;
+  constants_ = PlayerConstants::get_constants(user_color);
 }
+const PlayerColor PlayerObject::user_color() const { return color_; }
+
+const PlayerAnimationConstants& PlayerObject::constants() const { return constants_; }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -59,8 +59,43 @@ void Game::initialize() {
         {"character/capybara_default_duck_anim.png", "capybara_default_duck_anim_sheet", 1, 7},
 
         {"character/capybara_red_idle.png", "capybara_red_idle", 1, 1},
+        {"character/capybara_red_head.png", "capybara_red_head", 1, 1},
+        {"character/capybara_red_duck.png", "capybara_red_duck", 1, 1},
+        {"character/capybara_red_jump.png", "capybara_red_jump", 1, 1},
+        {"character/capybara_red_death.png", "capybara_red_death", 1, 1},
+        {"character/capybara_red_hit.png", "capybara_red_hit", 1, 1},
+        {"character/capybara_red_hit_anim.png", "capybara_red_hit_anim_sheet", 1, 8},
+        {"character/capybara_red_death_anim.png", "capybara_red_death_anim_sheet", 1, 8},
+        {"character/capybara_red_walk_anim.png", "capybara_red_walk_anim_sheet", 1, 8},
+        {"character/capybara_red_idle_anim.png", "capybara_red_idle_anim_sheet", 1, 7},
+        {"character/capybara_red_jump_anim.png", "capybara_red_jump_anim_sheet", 1, 7},
+        {"character/capybara_red_duck_anim.png", "capybara_red_duck_anim_sheet", 1, 7},
+
         {"character/capybara_blue_idle.png", "capybara_blue_idle", 1, 1},
+        {"character/capybara_blue_head.png", "capybara_blue_head", 1, 1},
+        {"character/capybara_blue_duck.png", "capybara_blue_duck", 1, 1},
+        {"character/capybara_blue_jump.png", "capybara_blue_jump", 1, 1},
+        {"character/capybara_blue_death.png", "capybara_blue_death", 1, 1},
+        {"character/capybara_blue_hit.png", "capybara_blue_hit", 1, 1},
+        {"character/capybara_blue_hit_anim.png", "capybara_blue_hit_anim_sheet", 1, 8},
+        {"character/capybara_blue_death_anim.png", "capybara_blue_death_anim_sheet", 1, 8},
+        {"character/capybara_blue_walk_anim.png", "capybara_blue_walk_anim_sheet", 1, 8},
+        {"character/capybara_blue_idle_anim.png", "capybara_blue_idle_anim_sheet", 1, 7},
+        {"character/capybara_blue_jump_anim.png", "capybara_blue_jump_anim_sheet", 1, 7},
+        {"character/capybara_blue_duck_anim.png", "capybara_blue_duck_anim_sheet", 1, 7},
+
         {"character/capybara_green_idle.png", "capybara_green_idle", 1, 1},
+        {"character/capybara_green_head.png", "capybara_green_head", 1, 1},
+        {"character/capybara_green_duck.png", "capybara_green_duck", 1, 1},
+        {"character/capybara_green_jump.png", "capybara_green_jump", 1, 1},
+        {"character/capybara_green_death.png", "capybara_green_death", 1, 1},
+        {"character/capybara_green_hit.png", "capybara_green_hit", 1, 1},
+        {"character/capybara_green_hit_anim.png", "capybara_green_hit_anim_sheet", 1, 8},
+        {"character/capybara_green_death_anim.png", "capybara_green_death_anim_sheet", 1, 8},
+        {"character/capybara_green_walk_anim.png", "capybara_green_walk_anim_sheet", 1, 8},
+        {"character/capybara_green_idle_anim.png", "capybara_green_idle_anim_sheet", 1, 7},
+        {"character/capybara_green_jump_anim.png", "capybara_green_jump_anim_sheet", 1, 7},
+        {"character/capybara_green_duck_anim.png", "capybara_green_duck_anim_sheet", 1, 7},
 
         // Player status bar
         {"character/heart.png", "heart_icon", 1, 1},
@@ -256,13 +291,37 @@ void Game::initialize() {
     Assets::register_textures(textures);
 
     const std::vector<LoadAnimation> sprite_sheets {
-        // Players
+        // Players - Default
         {"capybara_default_walk_anim_sheet", "capybara_default_walk_anim", 0, 8},
         {"capybara_default_idle_anim_sheet", "capybara_default_idle_anim", 0, 7},
         {"capybara_default_jump_anim_sheet", "capybara_default_jump_anim", 0, 7},
         {"capybara_default_duck_anim_sheet", "capybara_default_duck_anim", 0, 7},
         {"capybara_default_death_anim_sheet", "capybara_default_death_anim", 0, 7},
         {"capybara_default_hit_anim_sheet", "capybara_default_hit_anim", 0, 7},
+
+        // Players - Red
+        {"capybara_red_walk_anim_sheet", "capybara_red_walk_anim", 0, 8},
+        {"capybara_red_idle_anim_sheet", "capybara_red_idle_anim", 0, 7},
+        {"capybara_red_jump_anim_sheet", "capybara_red_jump_anim", 0, 7},
+        {"capybara_red_duck_anim_sheet", "capybara_red_duck_anim", 0, 7},
+        {"capybara_red_death_anim_sheet", "capybara_red_death_anim", 0, 7},
+        {"capybara_red_hit_anim_sheet", "capybara_red_hit_anim", 0, 7},
+
+        // Players - Blue
+        {"capybara_blue_walk_anim_sheet", "capybara_blue_walk_anim", 0, 8},
+        {"capybara_blue_idle_anim_sheet", "capybara_blue_idle_anim", 0, 7},
+        {"capybara_blue_jump_anim_sheet", "capybara_blue_jump_anim", 0, 7},
+        {"capybara_blue_duck_anim_sheet", "capybara_blue_duck_anim", 0, 7},
+        {"capybara_blue_death_anim_sheet", "capybara_blue_death_anim", 0, 7},
+        {"capybara_blue_hit_anim_sheet", "capybara_blue_hit_anim", 0, 7},
+
+        // Players - Green
+        {"capybara_green_walk_anim_sheet", "capybara_green_walk_anim", 0, 8},
+        {"capybara_green_idle_anim_sheet", "capybara_green_idle_anim", 0, 7},
+        {"capybara_green_jump_anim_sheet", "capybara_green_jump_anim", 0, 7},
+        {"capybara_green_duck_anim_sheet", "capybara_green_duck_anim", 0, 7},
+        {"capybara_green_death_anim_sheet", "capybara_green_death_anim", 0, 7},
+        {"capybara_green_hit_anim_sheet", "capybara_green_hit_anim", 0, 7},
 
         // Opponents
         {"drone_idle_anim_sheet", "drone_idle_anim", 0, 7},

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -4,6 +4,7 @@
 #include <game/scenes/swamp.h>
 #include <game/scenes/level.h>
 #include <game/scenes/swamp_autum.h>
+#include <game/scenes/lobby.h>
 
 #include <engine/audio/audio_service.h>
 #include <engine/core/engine.h>
@@ -293,7 +294,8 @@ void Game::initialize() {
     settings::apply_current_settings();
 
     levels_.emplace_back(std::make_unique<SwampScene>());
-    levels_.emplace_back(std::make_unique<SwampAutumScene>());
+    // levels_.emplace_back(std::make_unique<SwampAutumScene>());
+    levels_.emplace_back(std::make_unique<LobbyScene>());
 
     for (auto& level : levels_) {
         level->init();

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -294,8 +294,8 @@ void Game::initialize() {
     settings::apply_current_settings();
 
     levels_.emplace_back(std::make_unique<SwampScene>());
-    // levels_.emplace_back(std::make_unique<SwampAutumScene>());
     levels_.emplace_back(std::make_unique<LobbyScene>());
+    levels_.emplace_back(std::make_unique<SwampAutumScene>());
 
     for (auto& level : levels_) {
         level->init();

--- a/src/prefabs/character/dying_capybara_object.cpp
+++ b/src/prefabs/character/dying_capybara_object.cpp
@@ -1,7 +1,7 @@
 #include <game/prefabs/character/dying_capybara_object.h>
 #include <game/behaviors/ui/main_menu/main_menu_fall_behavior.h>
 #include <game/behaviors/dying_capybara_behavior.h>
-#include <game/character/playerConstants.h>
+#include <game/character/player_object.h>
 
 #include <engine/public/scene.h>
 #include <engine/public/components/animator.h>
@@ -12,7 +12,7 @@
 
 constexpr float size_modifier = 2.0f;
 
-DyingCapybaraObject::DyingCapybaraObject(Scene& scene, Vector3 position, float disappear_time)
+DyingCapybaraObject::DyingCapybaraObject(Scene& scene, Vector3 position, float disappear_time, PlayerColor color)
 : GameObject(scene),
   disappear_time_(disappear_time)
   {
@@ -20,9 +20,11 @@ DyingCapybaraObject::DyingCapybaraObject(Scene& scene, Vector3 position, float d
     this->transform().scale({size_modifier, size_modifier, 1.0f});
     this->transform().position(position);
     this->layer(Layers::Foreground);
+
+    auto constants = PlayerConstants::get_constants(color);
     
-    this->add_component<Sprite>(PlayerConstants::IDLE_TEXTURE, Color{255, 255, 255, 255}, 0, 0, 0, 0);
-    this->add_component<Animator>(PlayerConstants::DEATH_ANIMATION, 65);
+    this->add_component<Sprite>(constants.idle_texture.data(), Color{255, 255, 255, 255}, 0, 0, 0, 0);
+    this->add_component<Animator>(constants.death_animation.data(), 65);
     this->add_component<BehaviorScript>(std::make_unique<DyingCapybaraBehavior>(disappear_time_));
     this->add_component<Rigidbody2D>(BodyType2D::Dynamic, 30.0f, true, 3.0f);
     this->add_component<BoxCollider2D>(1.0f, 1.0f, 32.0f * size_modifier, 16.0f * size_modifier, Point{0.0f, 16.0f * size_modifier});

--- a/src/prefabs/ui/end_round_result_object.cpp
+++ b/src/prefabs/ui/end_round_result_object.cpp
@@ -50,9 +50,10 @@ EndRoundResultObject::EndRoundResultObject(Scene& scene, std::optional<std::refe
         0.0f
     });
 
+    std::string capybara_sprite = player_opt.has_value() ? player_opt.value().get().constants().death_animation.data() : "capybara_default_duck_anim";
     auto& capybara = scene.add_game_object("WinningCapybara");
     capybara.parent(*this);
-    capybara.add_component<Sprite>("capybara_default_duck_anim", Color(), 0, 0, 0, 0);
+    capybara.add_component<Sprite>(capybara_sprite, Color(), 0, 0, 0, 0);
     capybara.transform().scale({4.0f, 4.0f, 1.0f});
 
     float capybara_width = 32.0f * 4.0f;

--- a/src/round/roundcontroller.cpp
+++ b/src/round/roundcontroller.cpp
@@ -94,7 +94,7 @@ void RoundController::on_player_death(PlayerObject &player) {
 }
 
 void RoundController::spawn_dead_player(const PlayerObject &player) {
-  game_object().scene().add_game_object<DyingCapybaraObject>(game_object().scene(), player.transform().position(), 2.0f);  
+  game_object().scene().add_game_object<DyingCapybaraObject>(game_object().scene(), player.transform().position(), 2.0f, player.user_color());  
 }
 
 void RoundController::spawn_respawn_platform(const Vector3 &position, Vector3 spawn_position) {

--- a/src/scenes/lobby.cpp
+++ b/src/scenes/lobby.cpp
@@ -11,12 +11,29 @@
 
 #include <game/scenes/lobby.h>
 #include <game/character/player_object.h>
+#include <game/network/message_types.h>
+
+#include <iostream>
 
 constexpr float BUTTON_WIDTH = 400.0f;
 constexpr float BUTTON_HEIGHT = 80.0f;
 constexpr float BUTTON_FONT_SIZE = 46.0f;
 
-LobbyScene::LobbyScene() : Level("Level_LobbyScene") {}
+// float window_width = Engine::instance().services->get_service<RenderingService>().get().window().get_window_width();
+// float window_height = Engine::instance().services->get_service<RenderingService>().get().window().get_window_height();
+float window_width = 1920;
+float window_height = 1080;
+
+int max_players = 4;
+float frame_width = window_width / 10;
+float inner_frame_offset_x = frame_width / 2;
+float content_width = frame_width * max_players + inner_frame_offset_x * (max_players - 1);
+float outer_frame_offset_x = (window_width - content_width) / 2;
+float offset_y = window_height / 5 * 2;
+std::vector<std::string> colors = {"yellow", "red", "blue", "green"};
+std::vector<std::string> colors_2 = {"default", "red", "blue", "green"};
+
+LobbyScene::LobbyScene() : Level("Level_LobbyScene"), multiplayer_controller_{create_multiplayer_controller()} {}
 
 void LobbyScene::setup(Scene& scene) {
 
@@ -29,50 +46,146 @@ void LobbyScene::load(Scene& scene) {
     bg.add_component<Sprite>("main_menu_bg", Color{255, 255, 255, 255}, 0, 0, 0, 0);
     bg.transform().position({0, 0, 0});
 
-    auto& engine = Engine::instance();
-    auto& multiplayer_service = engine.services->get_service<MultiplayerService>().get();
-    auto& rendering_service = engine.services->get_service<RenderingService>().get();
+    auto& multiplayer_service = Engine::instance().services->get_service<MultiplayerService>().get();
 
     if (multiplayer_service.get_connection_state() == ConnectionState::NONE
         && multiplayer_service.get_peer_type() == PeerType::HOST) {
+        multiplayer_service.set_max_clients(4);
+        multiplayer_service.set_connection_port(1024);
         multiplayer_service.start_server();
+
+        if (auto controller_opt = multiplayer_controller_.get_script<BehaviorScript, MultiplayerController>(); controller_opt.has_value()) {
+            auto& controller = controller_opt.value().get();
+
+            controller.register_user(multiplayer_service.get_uuid());
+        }
     }
 
-    // TODO: If connectionstate == NONE, do the entire server creation thing if host
-    // TODO: Create four UI spots meant for player sprites and name
+    if (multiplayer_service.get_peer_type() == PeerType::HOST)
+        register_host_handlers(multiplayer_service);
+    else if (multiplayer_service.get_peer_type() == PeerType::CLIENT)
+        register_client_handlers(multiplayer_service);
 
-    float window_width = rendering_service.window().get_window_width();
-    float window_height = rendering_service.window().get_window_height();
+    create_ip_text();
+    create_player_displays(multiplayer_service);
+    create_start_button();
+}
 
-    int max_players = 4;
-    float frame_width = window_width / 10;
-    float inner_frame_offset_x = frame_width / 2;
-    float content_width = frame_width * max_players + inner_frame_offset_x * (max_players - 1);
-    float outer_frame_offset_x = (window_width - content_width) / 2;
-    float offset_y = window_height / 5 * 2;
-    std::vector<std::string> colors = {"yellow", "red", "blue", "green"};
-    std::vector<std::string> colors_2 = {"default", "red", "blue", "green"};
+GameObject& LobbyScene::create_multiplayer_controller() {
+    auto& obj = scene().add_game_object("MultiplayerController");
+    obj.add_component<BehaviorScript>(std::make_unique<MultiplayerController>());
+    
+    return obj;
+}
 
+void LobbyScene::register_host_handlers(MultiplayerService& multiplayer_service) {
+    multiplayer_service.register_handler(CustomMessageTypes::USER_JOIN, [&multiplayer_service, this](const Message& message) {
+        MsgUserJoin data{};
+        std::memcpy(&data, message.payload.data(), sizeof(data));
+
+        std::cout << "New user joined with UUID " << data.uuid << std::endl;
+        Message msg = serialize_message(data, CustomMessageTypes::USER_JOIN);
+        multiplayer_service.send(msg);
+
+        if (auto controller_opt = multiplayer_controller_.get_script<BehaviorScript, MultiplayerController>(); controller_opt.has_value()) {
+            auto& controller = controller_opt.value().get();
+
+            controller.register_user(data.uuid);
+            update_player_displays(multiplayer_service);
+        }
+    });
+    
+    multiplayer_service.register_handler(CustomMessageTypes::USER_LEAVE, [&multiplayer_service, this](const Message& message) {
+        MsgUserLeave data{};
+        std::memcpy(&data, message.payload.data(), sizeof(data));
+
+        std::cout << "User with UUID " << data.uuid << " left" << std::endl;
+        Message msg = serialize_message(data, CustomMessageTypes::USER_JOIN);
+        multiplayer_service.send(msg);
+
+        if (auto controller_opt = multiplayer_controller_.get_script<BehaviorScript, MultiplayerController>(); controller_opt.has_value()) {
+            auto& controller = controller_opt.value().get();
+
+            controller.unregister_user(data.uuid);
+            update_player_displays(multiplayer_service);
+        }
+    });
+}
+
+void LobbyScene::register_client_handlers(MultiplayerService& multiplayer_service) {
+    if (auto controller_opt = multiplayer_controller_.get_script<BehaviorScript, MultiplayerController>(); controller_opt.has_value()) {
+        auto& controller = controller_opt.value().get();
+
+        controller.on_connection_state_change([&multiplayer_service, this](ConnectionState old_state, ConnectionState new_state) {
+            if (new_state == ConnectionState::CONNECTED) {
+                std::cout << "Connected with UUID " << multiplayer_service.get_uuid() << std::endl;
+
+                MsgUserJoin data{};
+                std::strncpy(data.uuid, multiplayer_service.get_uuid().c_str(), sizeof(data.uuid) - 1);
+
+                Message msg = serialize_message(data, CustomMessageTypes::USER_JOIN);
+                multiplayer_service.send(msg);
+            }
+        });
+    }
+}
+
+void LobbyScene::create_ip_text() {
     std::string host_ip = "PLACEHOLDER IP";
 
-    auto& player_text = player_name(scene, host_ip, frame_width, 128);
+    auto& player_text = player_name(scene(), host_ip, frame_width, 128);
     player_text.transform().local_position({(window_width - frame_width) / 2, window_height / 7, 0});
+}
+
+void LobbyScene::update_player_displays(MultiplayerService& multiplayer_service) {
+    for (auto frame : player_frames_) {
+        scene().remove_game_object(*frame);
+    }
+    player_frames_.clear();
+    
+    create_player_displays(multiplayer_service);
+}
+
+void LobbyScene::create_player_displays(MultiplayerService& multiplayer_service) {
+    std::map<UserColor, std::string> users;
+
+    if (auto controller_opt = multiplayer_controller_.get_script<BehaviorScript, MultiplayerController>(); controller_opt.has_value()) {
+        auto& controller = controller_opt.value().get();
+
+        users = controller.users();
+    }
 
     for (int i = 0; i < max_players; ++i) {
         float offset = outer_frame_offset_x + (frame_width + inner_frame_offset_x) * i;
-        auto& player_text = player_name(scene, colors[i], frame_width, 48);
-        player_text.transform().local_position({offset, offset_y - 100, 0});
 
-        auto &player_background = scene.add_game_object<UIImage>(scene, "button_small_" + colors[i], frame_width, frame_width, Point{}, Point{});
-        player_background.transform().local_position({offset, offset_y, 0});
+        bool has_user = users.find(static_cast<UserColor>(i)) != users.end();
 
-        auto &player_skin_image = scene.add_game_object<UIImage>(scene, "capybara_" + colors_2[i] + "_idle", frame_width, frame_width, Point{}, Point{});
-        player_skin_image.transform().local_position({offset, offset_y - 10, 0});
+        if (has_user) {
+            auto& player_text = player_name(scene(), "PLACEHOLDER", frame_width, 48);
+            player_text.transform().local_position({offset, offset_y - 100, 0});
+            player_frames_.push_back(&player_text);
+
+            auto &player_background = scene().add_game_object<UIImage>(scene(), "button_small_" + colors[i], frame_width, frame_width, Point{}, Point{});
+            player_background.transform().local_position({offset, offset_y, 0});
+            player_frames_.push_back(&player_background);
+
+            auto &player_skin_image = scene().add_game_object<UIImage>(scene(), "capybara_" + colors_2[i] + "_idle", frame_width, frame_width, Point{}, Point{});
+            player_skin_image.transform().local_position({offset, offset_y - 10, 0});
+            player_frames_.push_back(&player_skin_image);
+        } else {
+            auto &player_background = scene().add_game_object<UIImage>(scene(), "button_small_black", frame_width, frame_width, Point{}, Point{});
+            player_background.transform().local_position({offset, offset_y, 0});
+            player_frames_.push_back(&player_background);
+        }
     }
+}
+
+void LobbyScene::create_start_button() {
+    auto& multiplayer_service = Engine::instance().services->get_service<MultiplayerService>().get();
 
     std::string start_btn_txt = multiplayer_service.get_peer_type() == PeerType::HOST ? "Start game" : "Waiting for Host";
     UIButton& start_button = create_button(
-        scene,
+        scene(),
         start_btn_txt,
         (window_width - BUTTON_WIDTH) / 2,
         window_height / 4 * 3,

--- a/src/scenes/lobby.cpp
+++ b/src/scenes/lobby.cpp
@@ -1,0 +1,135 @@
+#include <engine/core/engine.h>
+#include <engine/core/rendering/renderingService.h>
+#include <engine/network/multiplayer_service.h>
+#include <engine/audio/audio_service.h>
+#include <engine/public/components/sprite.h>
+#include <engine/public/components/ui/text.h>
+#include <engine/public/ui/ui_image.h>
+#include <engine/public/ui/ui_text.h>
+#include <engine/public/ui/interactable/ui_button.h>
+#include <engine/public/util/layers.h>
+
+#include <game/scenes/lobby.h>
+#include <game/character/player_object.h>
+
+constexpr float BUTTON_WIDTH = 400.0f;
+constexpr float BUTTON_HEIGHT = 80.0f;
+constexpr float BUTTON_FONT_SIZE = 46.0f;
+
+LobbyScene::LobbyScene() : Level("Level_LobbyScene") {}
+
+void LobbyScene::setup(Scene& scene) {
+
+}
+
+void LobbyScene::load(Scene& scene) {
+    LobbyScene::load_camera();
+
+    GameObject& bg = scene.add_game_object("Background");
+    bg.add_component<Sprite>("main_menu_bg", Color{255, 255, 255, 255}, 0, 0, 0, 0);
+    bg.transform().position({0, 0, 0});
+
+    auto& engine = Engine::instance();
+    auto& multiplayer_service = engine.services->get_service<MultiplayerService>().get();
+    auto& rendering_service = engine.services->get_service<RenderingService>().get();
+
+    if (multiplayer_service.get_connection_state() == ConnectionState::NONE
+        && multiplayer_service.get_peer_type() == PeerType::HOST) {
+        multiplayer_service.start_server();
+    }
+
+    // TODO: If connectionstate == NONE, do the entire server creation thing if host
+    // TODO: Create four UI spots meant for player sprites and name
+
+    float window_width = rendering_service.window().get_window_width();
+    float window_height = rendering_service.window().get_window_height();
+
+    int max_players = 4;
+    float frame_width = window_width / 10;
+    float inner_frame_offset_x = frame_width / 2;
+    float content_width = frame_width * max_players + inner_frame_offset_x * (max_players - 1);
+    float outer_frame_offset_x = (window_width - content_width) / 2;
+    float offset_y = window_height / 5 * 2;
+    std::vector<std::string> colors = {"yellow", "red", "blue", "green"};
+    std::vector<std::string> colors_2 = {"default", "red", "blue", "green"};
+
+    std::string host_ip = "PLACEHOLDER IP";
+
+    auto& player_text = player_name(scene, host_ip, frame_width, 128);
+    player_text.transform().local_position({(window_width - frame_width) / 2, window_height / 7, 0});
+
+    for (int i = 0; i < max_players; ++i) {
+        float offset = outer_frame_offset_x + (frame_width + inner_frame_offset_x) * i;
+        auto& player_text = player_name(scene, colors[i], frame_width, 48);
+        player_text.transform().local_position({offset, offset_y - 100, 0});
+
+        auto &player_background = scene.add_game_object<UIImage>(scene, "button_small_" + colors[i], frame_width, frame_width, Point{}, Point{});
+        player_background.transform().local_position({offset, offset_y, 0});
+
+        auto &player_skin_image = scene.add_game_object<UIImage>(scene, "capybara_" + colors_2[i] + "_idle", frame_width, frame_width, Point{}, Point{});
+        player_skin_image.transform().local_position({offset, offset_y - 10, 0});
+    }
+
+    std::string start_btn_txt = multiplayer_service.get_peer_type() == PeerType::HOST ? "Start game" : "Waiting for Host";
+    UIButton& start_button = create_button(
+        scene,
+        start_btn_txt,
+        (window_width - BUTTON_WIDTH) / 2,
+        window_height / 4 * 3,
+        "button_large_red"
+    );
+    // start_button.parent(parent);
+    if (multiplayer_service.get_peer_type() == PeerType::HOST) {
+        start_button.add_on_press([this](UIButton& /*btn*/) {
+            
+        });
+    } else {
+        start_button.disable();
+    }
+}
+
+UIButton& LobbyScene::create_button(
+    Scene& scene,
+    const std::string& label, 
+    float position_x,
+    float position_y, 
+    const std::string& texture_id
+) {
+    UIButton& button = scene.add_game_object<UIButton>(
+        scene,
+        BUTTON_WIDTH,
+        BUTTON_HEIGHT,
+        Point{0.5f, 0.5f},
+        Point{0.5f, 0.5f},
+        label,
+        "ByteBounce",
+        "resources/fonts/bytebounce/ByteBounce.ttf",
+        texture_id
+    );
+    button.transform().position({position_x, position_y, 0.0f});
+    button.label_color(Color{255, 255, 255, 255});
+    button.font_size(BUTTON_FONT_SIZE);
+    button.layer(Layers::UI);
+
+    button.add_on_hover([] (UIInteractable&) {
+      auto& audio_service = Engine::instance().services->get_service<AudioService>().get();
+      audio_service.play_sound("btn_hover", 0.1f);
+    });
+
+    return button;
+}
+
+UIText& LobbyScene::player_name(Scene &scene, const std::string& username, float frame_width, float font_size) {
+    UIText &player_name = scene.add_game_object<UIText>(
+        scene,
+        username,
+        "ByteBounce",
+        "resources/fonts/bytebounce/ByteBounce.ttf",
+        frame_width,
+        BUTTON_HEIGHT,
+        Point{},
+        Point{});
+
+    player_name.font_size(font_size);
+    return player_name;
+}

--- a/src/scenes/lobby.cpp
+++ b/src/scenes/lobby.cpp
@@ -20,19 +20,15 @@ constexpr float BUTTON_WIDTH = 400.0f;
 constexpr float BUTTON_HEIGHT = 80.0f;
 constexpr float BUTTON_FONT_SIZE = 46.0f;
 
-// float window_width = Engine::instance().services->get_service<RenderingService>().get().window().get_window_width();
-// float window_height = Engine::instance().services->get_service<RenderingService>().get().window().get_window_height();
-float window_width = 1920;
-float window_height = 1080;
+constexpr float WINDOW_WIDTH = 1920;
+constexpr float WINDOW_HEIGHT = 1080;
 
-int max_players = 4;
-float frame_width = window_width / 10;
-float inner_frame_offset_x = frame_width / 2;
-float content_width = frame_width * max_players + inner_frame_offset_x * (max_players - 1);
-float outer_frame_offset_x = (window_width - content_width) / 2;
-float offset_y = window_height / 5 * 2;
-std::vector<std::string> colors = {"yellow", "red", "blue", "green"};
-std::vector<std::string> colors_2 = {"default", "red", "blue", "green"};
+constexpr int MAX_PLAYERS = 4;
+constexpr float FRAME_WIDTH = WINDOW_WIDTH / 10;
+constexpr float INNER_FRAME_OFFSET_X = FRAME_WIDTH / 2;
+constexpr float CONTENT_WIDTH = FRAME_WIDTH * MAX_PLAYERS + INNER_FRAME_OFFSET_X * (MAX_PLAYERS - 1);
+constexpr float OUTER_FRAME_OFFSET_X = (WINDOW_WIDTH - CONTENT_WIDTH) / 2;
+constexpr float OFFSET_Y = WINDOW_HEIGHT / 5 * 2;
 
 LobbyScene::LobbyScene() : Level("Level_LobbyScene"), multiplayer_controller_{create_multiplayer_controller()} {}
 
@@ -194,8 +190,8 @@ void LobbyScene::register_client_handlers(MultiplayerService& multiplayer_servic
 void LobbyScene::create_ip_text() {
     std::string host_ip = "PLACEHOLDER IP";
 
-    auto& player_text = player_name(scene(), host_ip, frame_width, 128);
-    player_text.transform().local_position({(window_width - frame_width) / 2, window_height / 7, 0});
+    auto& player_text = player_name(scene(), host_ip, FRAME_WIDTH, 128);
+    player_text.transform().local_position({(WINDOW_WIDTH - FRAME_WIDTH) / 2, WINDOW_HEIGHT / 7, 0});
 }
 
 void LobbyScene::update_player_displays(MultiplayerService& multiplayer_service) {
@@ -216,26 +212,29 @@ void LobbyScene::create_player_displays(MultiplayerService& multiplayer_service)
         users = controller.users();
     }
 
-    for (int i = 0; i < max_players; ++i) {
-        float offset = outer_frame_offset_x + (frame_width + inner_frame_offset_x) * i;
+    for (int i = 0; i < MAX_PLAYERS; ++i) {
+        float offset = OUTER_FRAME_OFFSET_X + (FRAME_WIDTH + INNER_FRAME_OFFSET_X) * i;
 
         bool has_user = users.find(static_cast<UserColor>(i)) != users.end();
 
         if (has_user) {
-            auto& player_text = player_name(scene(), "PLACEHOLDER", frame_width, 48);
-            player_text.transform().local_position({offset, offset_y - 100, 0});
+            std::vector<std::string> btn_colors = {"yellow", "red", "blue", "green"};
+            std::vector<std::string> skin_colors = {"default", "red", "blue", "green"};
+
+            auto& player_text = player_name(scene(), "PLACEHOLDER", FRAME_WIDTH, 48);
+            player_text.transform().local_position({offset, OFFSET_Y - 100, 0});
             player_frames_.push_back(std::ref(player_text));
 
-            auto &player_background = scene().add_game_object<UIImage>(scene(), "button_small_" + colors[i], frame_width, frame_width, Point{}, Point{});
-            player_background.transform().local_position({offset, offset_y, 0});
+            auto &player_background = scene().add_game_object<UIImage>(scene(), "button_small_" + btn_colors[i], FRAME_WIDTH, FRAME_WIDTH, Point{}, Point{});
+            player_background.transform().local_position({offset, OFFSET_Y, 0});
             player_frames_.push_back(std::ref(player_background));
 
-            auto &player_skin_image = scene().add_game_object<UIImage>(scene(), "capybara_" + colors_2[i] + "_idle", frame_width, frame_width, Point{}, Point{});
-            player_skin_image.transform().local_position({offset, offset_y - 10, 0});
+            auto &player_skin_image = scene().add_game_object<UIImage>(scene(), "capybara_" + skin_colors[i] + "_idle", FRAME_WIDTH, FRAME_WIDTH, Point{}, Point{});
+            player_skin_image.transform().local_position({offset, OFFSET_Y - 10, 0});
             player_frames_.push_back(std::ref(player_skin_image));
         } else {
-            auto &player_background = scene().add_game_object<UIImage>(scene(), "button_small_black", frame_width, frame_width, Point{}, Point{});
-            player_background.transform().local_position({offset, offset_y, 0});
+            auto &player_background = scene().add_game_object<UIImage>(scene(), "button_small_black", FRAME_WIDTH, FRAME_WIDTH, Point{}, Point{});
+            player_background.transform().local_position({offset, OFFSET_Y, 0});
             player_frames_.push_back(std::ref(player_background));
         }
     }
@@ -248,8 +247,8 @@ void LobbyScene::create_start_button() {
     UIButton& start_button = create_button(
         scene(),
         start_btn_txt,
-        (window_width - BUTTON_WIDTH) / 2,
-        window_height / 4 * 3,
+        (WINDOW_WIDTH - BUTTON_WIDTH) / 2,
+        WINDOW_HEIGHT / 4 * 3,
         "button_large_red"
     );
 

--- a/src/scenes/lobby.cpp
+++ b/src/scenes/lobby.cpp
@@ -172,7 +172,6 @@ void LobbyScene::register_client_handlers(MultiplayerService& multiplayer_servic
     });
 
     multiplayer_service.register_handler(CustomMessageTypes::ROUND_START, [&multiplayer_service, this](const Message& message) {
-        // TODO: Unregister handlers
         auto& scene_service = Engine::instance().services->get_service<SceneService>().get();
         scene_service.load_scene("Level_SwampAutumScene");
     });
@@ -253,7 +252,7 @@ void LobbyScene::create_start_button() {
         window_height / 4 * 3,
         "button_large_red"
     );
-    // start_button.parent(parent);
+
     if (multiplayer_service.get_peer_type() == PeerType::HOST) {
         start_button.add_on_press([this](UIButton& /*btn*/) {
             if (auto controller_opt = multiplayer_controller_.get_script<BehaviorScript, MultiplayerController>(); controller_opt.has_value()) {
@@ -265,8 +264,6 @@ void LobbyScene::create_start_button() {
                 Message msg = serialize_message(data, CustomMessageTypes::ROUND_START);
                 Engine::instance().services->get_service<MultiplayerService>().get().send(msg);
 
-                // TODO: Also unregister listeners
-                // TODO: Switch scene and load data to start the game
                 auto& scene_service = Engine::instance().services->get_service<SceneService>().get();
                 scene_service.load_scene("Level_SwampAutumScene");
             }

--- a/src/scenes/lobby.cpp
+++ b/src/scenes/lobby.cpp
@@ -83,9 +83,72 @@ void LobbyScene::register_host_handlers(MultiplayerService& multiplayer_service)
         MsgUserJoin data{};
         std::memcpy(&data, message.payload.data(), sizeof(data));
 
-        std::cout << "New user joined with UUID " << data.uuid << std::endl;
+        if (auto controller_opt = multiplayer_controller_.get_script<BehaviorScript, MultiplayerController>(); controller_opt.has_value()) {
+            auto& controller = controller_opt.value().get();
+
+            controller.register_user(data.uuid);
+            update_player_displays(multiplayer_service);
+            
+            MsgLobbyData lobby_data{};
+            lobby_data.user_count = 0;
+            for (auto [key, value] : controller.users()) {
+                LobbyUserData user_data{};
+                std::strncpy(user_data.uuid, value.uuid.c_str(), sizeof(user_data.uuid) - 1);
+                user_data.color = static_cast<uint16_t>(value.color);
+                std::strncpy(user_data.name, value.username.c_str(), sizeof(user_data.name) - 1);
+
+                lobby_data.users[lobby_data.user_count] = user_data;
+                ++lobby_data.user_count;
+            }
+
+            Message lobby_msg = serialize_message(lobby_data, CustomMessageTypes::LOBBY_DATA);
+            multiplayer_service.send_to_peer_via_uuid(data.uuid, lobby_msg);
+        }
+
         Message msg = serialize_message(data, CustomMessageTypes::USER_JOIN);
         multiplayer_service.send(msg);
+    });
+    
+    multiplayer_service.register_handler(CustomMessageTypes::USER_LEAVE, [&multiplayer_service, this](const Message& message) {
+        MsgUserLeave data{};
+        std::memcpy(&data, message.payload.data(), sizeof(data));
+
+        Message msg = serialize_message(data, CustomMessageTypes::USER_LEAVE);
+        multiplayer_service.send(msg);
+
+        if (auto controller_opt = multiplayer_controller_.get_script<BehaviorScript, MultiplayerController>(); controller_opt.has_value()) {
+            auto& controller = controller_opt.value().get();
+
+            controller.unregister_user(data.uuid);
+            update_player_displays(multiplayer_service);
+        }
+    });
+}
+
+void LobbyScene::register_client_handlers(MultiplayerService& multiplayer_service) {
+    multiplayer_service.register_handler(CustomMessageTypes::LOBBY_DATA, [&multiplayer_service, this](const Message& message) {
+        MsgLobbyData data{};
+        std::memcpy(&data, message.payload.data(), sizeof(data));
+
+        if (auto controller_opt = multiplayer_controller_.get_script<BehaviorScript, MultiplayerController>(); controller_opt.has_value()) {
+            auto& controller = controller_opt.value().get();
+            
+            for (uint32_t i = 0; i < data.user_count; ++i) {
+                LobbyUserData user_data{};
+                std::memcpy(&user_data, &data.users[i], sizeof(user_data));
+                
+                controller.register_user(user_data.uuid, user_data.name, static_cast<UserColor>(user_data.color));
+            }
+            
+            update_player_displays(multiplayer_service);
+        }
+    });
+
+    multiplayer_service.register_handler(CustomMessageTypes::USER_JOIN, [&multiplayer_service, this](const Message& message) {
+        MsgUserJoin data{};
+        std::memcpy(&data, message.payload.data(), sizeof(data));
+
+        if (data.uuid == multiplayer_service.get_uuid()) return;
 
         if (auto controller_opt = multiplayer_controller_.get_script<BehaviorScript, MultiplayerController>(); controller_opt.has_value()) {
             auto& controller = controller_opt.value().get();
@@ -99,10 +162,6 @@ void LobbyScene::register_host_handlers(MultiplayerService& multiplayer_service)
         MsgUserLeave data{};
         std::memcpy(&data, message.payload.data(), sizeof(data));
 
-        std::cout << "User with UUID " << data.uuid << " left" << std::endl;
-        Message msg = serialize_message(data, CustomMessageTypes::USER_JOIN);
-        multiplayer_service.send(msg);
-
         if (auto controller_opt = multiplayer_controller_.get_script<BehaviorScript, MultiplayerController>(); controller_opt.has_value()) {
             auto& controller = controller_opt.value().get();
 
@@ -110,16 +169,12 @@ void LobbyScene::register_host_handlers(MultiplayerService& multiplayer_service)
             update_player_displays(multiplayer_service);
         }
     });
-}
 
-void LobbyScene::register_client_handlers(MultiplayerService& multiplayer_service) {
     if (auto controller_opt = multiplayer_controller_.get_script<BehaviorScript, MultiplayerController>(); controller_opt.has_value()) {
         auto& controller = controller_opt.value().get();
 
         controller.on_connection_state_change([&multiplayer_service, this](ConnectionState old_state, ConnectionState new_state) {
             if (new_state == ConnectionState::CONNECTED) {
-                std::cout << "Connected with UUID " << multiplayer_service.get_uuid() << std::endl;
-
                 MsgUserJoin data{};
                 std::strncpy(data.uuid, multiplayer_service.get_uuid().c_str(), sizeof(data.uuid) - 1);
 
@@ -139,7 +194,7 @@ void LobbyScene::create_ip_text() {
 
 void LobbyScene::update_player_displays(MultiplayerService& multiplayer_service) {
     for (auto frame : player_frames_) {
-        scene().remove_game_object(*frame);
+        scene().remove_game_object(frame.get());
     }
     player_frames_.clear();
     
@@ -147,7 +202,7 @@ void LobbyScene::update_player_displays(MultiplayerService& multiplayer_service)
 }
 
 void LobbyScene::create_player_displays(MultiplayerService& multiplayer_service) {
-    std::map<UserColor, std::string> users;
+    std::map<UserColor, User> users;
 
     if (auto controller_opt = multiplayer_controller_.get_script<BehaviorScript, MultiplayerController>(); controller_opt.has_value()) {
         auto& controller = controller_opt.value().get();
@@ -163,19 +218,19 @@ void LobbyScene::create_player_displays(MultiplayerService& multiplayer_service)
         if (has_user) {
             auto& player_text = player_name(scene(), "PLACEHOLDER", frame_width, 48);
             player_text.transform().local_position({offset, offset_y - 100, 0});
-            player_frames_.push_back(&player_text);
+            player_frames_.push_back(std::ref(player_text));
 
             auto &player_background = scene().add_game_object<UIImage>(scene(), "button_small_" + colors[i], frame_width, frame_width, Point{}, Point{});
             player_background.transform().local_position({offset, offset_y, 0});
-            player_frames_.push_back(&player_background);
+            player_frames_.push_back(std::ref(player_background));
 
             auto &player_skin_image = scene().add_game_object<UIImage>(scene(), "capybara_" + colors_2[i] + "_idle", frame_width, frame_width, Point{}, Point{});
             player_skin_image.transform().local_position({offset, offset_y - 10, 0});
-            player_frames_.push_back(&player_skin_image);
+            player_frames_.push_back(std::ref(player_skin_image));
         } else {
             auto &player_background = scene().add_game_object<UIImage>(scene(), "button_small_black", frame_width, frame_width, Point{}, Point{});
             player_background.transform().local_position({offset, offset_y, 0});
-            player_frames_.push_back(&player_background);
+            player_frames_.push_back(std::ref(player_background));
         }
     }
 }

--- a/src/scenes/lobby.cpp
+++ b/src/scenes/lobby.cpp
@@ -8,6 +8,7 @@
 #include <engine/public/ui/ui_text.h>
 #include <engine/public/ui/interactable/ui_button.h>
 #include <engine/public/util/layers.h>
+#include <engine/public/scene_service.h>
 
 #include <game/scenes/lobby.h>
 #include <game/character/player_object.h>
@@ -36,7 +37,7 @@ std::vector<std::string> colors_2 = {"default", "red", "blue", "green"};
 LobbyScene::LobbyScene() : Level("Level_LobbyScene"), multiplayer_controller_{create_multiplayer_controller()} {}
 
 void LobbyScene::setup(Scene& scene) {
-
+    multiplayer_controller_.mark_dont_destroy_on_load(true);
 }
 
 void LobbyScene::load(Scene& scene) {
@@ -170,6 +171,12 @@ void LobbyScene::register_client_handlers(MultiplayerService& multiplayer_servic
         }
     });
 
+    multiplayer_service.register_handler(CustomMessageTypes::ROUND_START, [&multiplayer_service, this](const Message& message) {
+        // TODO: Unregister handlers
+        auto& scene_service = Engine::instance().services->get_service<SceneService>().get();
+        scene_service.load_scene("Level_SwampAutumScene");
+    });
+
     if (auto controller_opt = multiplayer_controller_.get_script<BehaviorScript, MultiplayerController>(); controller_opt.has_value()) {
         auto& controller = controller_opt.value().get();
 
@@ -249,7 +256,20 @@ void LobbyScene::create_start_button() {
     // start_button.parent(parent);
     if (multiplayer_service.get_peer_type() == PeerType::HOST) {
         start_button.add_on_press([this](UIButton& /*btn*/) {
-            
+            if (auto controller_opt = multiplayer_controller_.get_script<BehaviorScript, MultiplayerController>(); controller_opt.has_value()) {
+                auto& controller = controller_opt.value().get();
+
+                if (controller.users().size() < 2) return;
+
+                MsgRoundStart data{};
+                Message msg = serialize_message(data, CustomMessageTypes::ROUND_START);
+                Engine::instance().services->get_service<MultiplayerService>().get().send(msg);
+
+                // TODO: Also unregister listeners
+                // TODO: Switch scene and load data to start the game
+                auto& scene_service = Engine::instance().services->get_service<SceneService>().get();
+                scene_service.load_scene("Level_SwampAutumScene");
+            }
         });
     } else {
         start_button.disable();

--- a/src/scenes/swamp_autum.cpp
+++ b/src/scenes/swamp_autum.cpp
@@ -79,7 +79,7 @@ GameObject& SwampAutumScene::create_interactable_dropper(const std::string& name
 
     Engine& engine = Engine::instance();
     auto& multiplayer_service = engine.services->get_service<MultiplayerService>().get();
-    obj.add_component<NetworkIdentity>(name.c_str());
+    obj.add_component<NetworkIdentity>(name.c_str()).mark_dirty();
 
     return obj;
 }
@@ -99,11 +99,11 @@ RoundController& SwampAutumScene::add_multiplayer_round_controller() {
     return controller;
 }
 
-MultiplayerController& SwampAutumScene::add_multiplayer_controller() {
-    GameObject& wrapper = scene().add_game_object("MultiplayerControllerWrapper");
-    auto& comp = wrapper.add_component<BehaviorScript>(std::make_unique<MultiplayerController>());
-    return *dynamic_cast<MultiplayerController*>(&comp.behavior());
-}
+// MultiplayerController& SwampAutumScene::add_multiplayer_controller() {
+//     GameObject& wrapper = scene().add_game_object("MultiplayerControllerWrapper");
+//     auto& comp = wrapper.add_component<BehaviorScript>(std::make_unique<MultiplayerController>());
+//     return *dynamic_cast<MultiplayerController*>(&comp.behavior());
+// }
 
 std::optional<std::reference_wrapper<PlayerObject>> SwampAutumScene::get_network_player_object(const std::string& uuid) {
     for (auto& game_object_ref : scene().game_objects()) {
@@ -206,72 +206,41 @@ void SwampAutumScene::load(Scene& scene) {
     Engine& engine = Engine::instance();
     auto& multiplayer_service = engine.services->get_service<MultiplayerService>().get();
     auto& prefab_service = engine.services->get_service<PrefabService>().get();
-    RoundController& controller = add_multiplayer_round_controller();
+    RoundController& round_controller = add_multiplayer_round_controller();
+    
+    std::optional<std::reference_wrapper<GameObject>> multiplayer_controller_opt;
 
-    MultiplayerController& multiplayer_controller = add_multiplayer_controller();
+    for (auto& obj : scene.game_objects()) {
+        if (obj.get().name() == "MultiplayerController") {
+            multiplayer_controller_opt = obj;
+            break;
+        }
+    }
+
+    if (multiplayer_controller_opt.has_value()) {
+        auto& multiplayer_controller = multiplayer_controller_opt.value().get();
+        if (auto multiplayer_controller_behavior_opt = multiplayer_controller.get_script<BehaviorScript, MultiplayerController>(); multiplayer_controller_behavior_opt.has_value()) {
+            auto& multiplayer_controller_behavior = multiplayer_controller_behavior_opt.value().get();
+
+            for (auto& [key, value] : multiplayer_controller_behavior.users()) {
+                auto& player = *dynamic_cast<PlayerObject*>(&prefab_service.instantiate("PlayerObject", scene, value.uuid).get());
+
+                if (value.uuid == multiplayer_service.get_uuid()) {
+                    player.set_local_player();
+                    player.set_controllable();
+                }
+
+                round_controller.add_player(player);
+            }
+        }
+    }
+
     if (multiplayer_service.get_peer_type() == PeerType::HOST) {
-        multiplayer_service.set_max_clients(4);
-        multiplayer_service.set_connection_port(1024);
-        multiplayer_service.start_server();
-
-        multiplayer_service.register_handler(CustomMessageTypes::USER_JOIN, [&multiplayer_service, &controller, &prefab_service, &scene](const Message& message) {
-            MsgUserJoin data{};
-            std::memcpy(&data, message.payload.data(), sizeof(data));
-
-            std::cout << "New user joined with UUID " << data.uuid << std::endl;
-            Message msg = serialize_message(data, CustomMessageTypes::USER_JOIN);
-            multiplayer_service.send(msg);
-
-            auto& player = *dynamic_cast<PlayerObject*>(&prefab_service.instantiate("PlayerObject", scene, data.uuid).get());
-            controller.add_player(player);
-        });
-
         register_host_handlers(multiplayer_service, scene, prefab_service);
-
-        auto& player = *dynamic_cast<PlayerObject*>(&prefab_service.instantiate("PlayerObject", scene, multiplayer_service.get_uuid().c_str()).get());
-        player.set_local_player();
-        player.set_controllable();
-        controller.add_player(player);
 
         SwampAutumScene::load_interactables(scene);
     } else {
-        multiplayer_controller.on_connection_state_change([&scene, &multiplayer_service, &controller](ConnectionState old_state, ConnectionState new_state) {
-            if (new_state == ConnectionState::CONNECTED) {
-                std::cout << "Connected with UUID " << multiplayer_service.get_uuid() << std::endl;
-
-                MsgUserJoin data{};
-                std::strncpy(data.uuid, multiplayer_service.get_uuid().c_str(), sizeof(data.uuid) - 1);
-
-                Message msg = serialize_message(data, CustomMessageTypes::USER_JOIN);
-                multiplayer_service.send(msg);
-
-                // Sync unregistered player objects
-                for (auto& game_object_ref : scene.game_objects()) {
-                    auto& game_object = game_object_ref.get();
-                    if (auto player = dynamic_cast<PlayerObject*>(&game_object)) {
-                        if (!controller.is_player_registered(*player)) {
-                            controller.add_player(*player);
-                        }
-                    }
-                }
-            }
-        });
-
-        multiplayer_service.register_handler(CustomMessageTypes::USER_JOIN, [&multiplayer_service, &controller, &prefab_service, &scene](const Message& message) {
-            MsgUserJoin data{};
-            std::memcpy(&data, message.payload.data(), sizeof(data));
-
-            std::cout << "New user joined with UUID " << data.uuid << std::endl;
-
-            auto& player = *dynamic_cast<PlayerObject*>(&prefab_service.instantiate("PlayerObject", scene, data.uuid).get());
-            controller.add_player(player);
-            if (data.uuid == multiplayer_service.get_uuid()) {
-                player.set_local_player();
-                player.set_controllable();
-            }
-        });
-
-        register_client_handlers(multiplayer_service, scene, prefab_service, controller);
+        register_client_handlers(multiplayer_service, scene, prefab_service, round_controller);
     }
 }
 

--- a/src/scenes/swamp_autum.cpp
+++ b/src/scenes/swamp_autum.cpp
@@ -169,8 +169,18 @@ void SwampAutumScene::handle_player_drop_weapon(const MsgUserDropWeapon& data) {
 
 void SwampAutumScene::setup(Scene& scene) {
     add_on_stop_callback([](Scene& scene) {
+        auto& audio_service = Engine::instance().services->get_service<AudioService>().get();
+        audio_service.stop_all_sounds();
+
         auto& multiplayer_service = Engine::instance().services->get_service<MultiplayerService>().get();
-        multiplayer_service.disconnect();
+        multiplayer_service.unregister_handler(CustomMessageTypes::USER_DROP_WEAPON);
+        multiplayer_service.unregister_handler(CustomMessageTypes::USER_MOVE);
+        multiplayer_service.unregister_handler(CustomMessageTypes::USER_ATTACK);
+
+        if (multiplayer_service.get_peer_type() == PeerType::CLIENT) {
+            multiplayer_service.unregister_handler(CustomMessageTypes::USER_RESPAWN);
+            multiplayer_service.unregister_handler(CustomMessageTypes::DROP_SPAWN);
+        }
     });
 
     PrefabService& prefab_service = Engine::instance().services->get_service<PrefabService>().get();

--- a/src/scenes/swamp_autum.cpp
+++ b/src/scenes/swamp_autum.cpp
@@ -99,12 +99,6 @@ RoundController& SwampAutumScene::add_multiplayer_round_controller() {
     return controller;
 }
 
-// MultiplayerController& SwampAutumScene::add_multiplayer_controller() {
-//     GameObject& wrapper = scene().add_game_object("MultiplayerControllerWrapper");
-//     auto& comp = wrapper.add_component<BehaviorScript>(std::make_unique<MultiplayerController>());
-//     return *dynamic_cast<MultiplayerController*>(&comp.behavior());
-// }
-
 std::optional<std::reference_wrapper<PlayerObject>> SwampAutumScene::get_network_player_object(const std::string& uuid) {
     for (auto& game_object_ref : scene().game_objects()) {
         auto& game_object = game_object_ref.get();

--- a/src/scenes/swamp_autum.cpp
+++ b/src/scenes/swamp_autum.cpp
@@ -224,6 +224,8 @@ void SwampAutumScene::load(Scene& scene) {
 
             for (auto& [key, value] : multiplayer_controller_behavior.users()) {
                 auto& player = *dynamic_cast<PlayerObject*>(&prefab_service.instantiate("PlayerObject", scene, value.uuid).get());
+                player.user_name(value.username);
+                player.user_color(static_cast<PlayerColor>(value.color));
 
                 if (value.uuid == multiplayer_service.get_uuid()) {
                     player.set_local_player();


### PR DESCRIPTION
Add the lobby with a bunch of other functionalities:
- Game lobby is created when a player creates a game
  - When another player joins, they're visible in the lobby with a different capybara color
  - Only the host can start the game with the 'start game' button
  - When the game has started, all players present in the lobby will switch to the game scene

- When the game ends, all players will be transported back to the lobby

There are two known bugs that will be fixed in a different branch since they're either bugs that have existed for a while or need a fix that includes more than just the lobby (prefabs & rejoining bugs)

Two upcoming features have placeholders:
- Player names
- Host IP