### PR TITLE
fix (swamp): unsub on destroy

### DIFF
--- a/src/scenes/swamp.cpp
+++ b/src/scenes/swamp.cpp
@@ -124,6 +124,11 @@ void SwampScene::setup(Scene& scene) {
     scene.on_stop([&audio_service](Scene& scene) {
         audio_service.stop_all_sounds();
     });
+
+    this->add_on_stop_callback([this](Scene& scene) {
+        this->on_player_lives_changed_subscription_.reset();
+        this->on_ai_lives_changed_subscription_.reset();
+    });
 }
 
 void SwampScene::load(Scene& scene) {


### PR DESCRIPTION
This fixes the segfault on the second attempt to start training due to not reseting subscribers on leaving