### PR TITLE
fix (movement): add ceiling jump check

### DIFF
--- a/src/character/player_movement_behavior.cpp
+++ b/src/character/player_movement_behavior.cpp
@@ -68,9 +68,15 @@ void PlayerMovementBehavior::on_start() {
       if (other.parent()->get().tag() != "Ground")
         return;
 
-      is_grounded_ = true;
-      is_jumping_ = false;
-      is_double_jumping_ = false;
+      auto self_transform = self.parent()->get().transform();
+      auto other_transform = other.parent()->get().transform();
+
+      /// Y is inverted in the engine
+      if (self_transform.position().y < other_transform.position().y) {
+        is_grounded_ = true;
+        is_jumping_ = false;
+        is_double_jumping_ = false;
+      }
     });
 
   move_sound_opt_ = audio_service_->get().play_sound("player_move", 0.1f, true);


### PR DESCRIPTION
This PR address the bug where you can keep jumping on the ceiling. Now we do a simple position check to see if you are colliding with something below you as the ground is always lower. Also the engine Y-axis is inverted as noted to avoid confusion