### PR TITLE
fix (training): ai capybara appearing in front of bushes

### DIFF
--- a/include/game/scripts/timer/RoundTimer.h
+++ b/include/game/scripts/timer/RoundTimer.h
@@ -70,6 +70,5 @@ private:
         text_.value().get().transform().position({1920 / 2.0f - 500 / 2.0f, 0.0f, 0.0f}); // Horizontal center
         text_.value().get().color({255, 255, 255, 255});
         text_.value().get().font_size(96);
-        text_.value().get().layer(Layers::UI);
     }
 };

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -427,7 +427,6 @@ void Game::bootstrap(Scene& first_scene) {
 
     auto& fps_counter = first_scene.add_game_object<UIFPS>(first_scene);
     fps_counter.mark_dont_destroy_on_load(true);
-    fps_counter.layer(Layers::UI);
 
     auto& fps_controller = first_scene.add_game_object("FPS Toggle");
     fps_controller.add_component<BehaviorScript>(std::make_unique<ObjectToggleBehavior>(fps_counter));

--- a/src/scenes/lobby.cpp
+++ b/src/scenes/lobby.cpp
@@ -297,7 +297,6 @@ UIButton& LobbyScene::create_button(
     button.transform().position({position_x, position_y, 0.0f});
     button.label_color(Color{255, 255, 255, 255});
     button.font_size(BUTTON_FONT_SIZE);
-    button.layer(Layers::UI);
 
     button.add_on_hover([] (UIInteractable&) {
       auto& audio_service = Engine::instance().services->get_service<AudioService>().get();

--- a/src/scenes/main_menu.cpp
+++ b/src/scenes/main_menu.cpp
@@ -385,7 +385,6 @@ UIInput& MainMenuScene::create_input(
     );
     input.transform().position({position_x, position_y, 0.0f});
     input.font_size(BUTTON_FONT_SIZE);
-    input.layer(Layers::UI);
 
     return input;
 }
@@ -413,7 +412,6 @@ UIText& MainMenuScene::create_text(
     text.transform().position({position_x, position_y, 0.0f});
     text.font_size(font_size);
     text.color(color);
-    text.layer(Layers::UI);
 
     return text;
 }
@@ -439,7 +437,6 @@ UIButton& MainMenuScene::create_button(
     button.transform().position({position_x, position_y, 0.0f});
     button.label_color(Color{255, 255, 255, 255});
     button.font_size(BUTTON_FONT_SIZE);
-    button.layer(Layers::UI);
 
     button.add_on_hover([] (UIInteractable&) {
       auto& audio_service = Engine::instance().services->get_service<AudioService>().get();

--- a/src/scenes/swamp.cpp
+++ b/src/scenes/swamp.cpp
@@ -47,6 +47,7 @@ void SwampScene::load_players(Scene& scene, RoundController& controller, float s
 
     auto& ai_player = scene.add_game_object<PlayerObject>(scene, Vector3{start_x + 40.0f, 100.0f, 0}, false);
     ai_player.user_name("AI Player");
+    ai_player.layer(Layers::Foreground);
     ai_player.add_component<BehaviorScript>(std::make_unique<PlayerOutOfBoundsBehavior>(
       -out_of_bounds_margin_x_,
       map_width_ + out_of_bounds_margin_x_,


### PR DESCRIPTION
> [!warning]
>This PR depends on Engine PR [#190](https://github.com/SPC-F/CapycoreEngine/pull/190)

Changed layer of the AI capybara
Also removed unneeded UI layer allocations